### PR TITLE
Update to .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>    
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>preview</LangVersion>    
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>    

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,11 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="dotNetRdf" Version="3.2.0" />
+    <PackageVersion Include="dotNetRdf" Version="3.2.1" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageVersion Include="JunitXml.TestLogger" Version="3.1.12" />
+    <PackageVersion Include="JunitXml.TestLogger" Version="4.0.254" />
     <PackageVersion Include="LiquidTestReports.Markdown" Version="1.4.3-beta" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
-  "sdk": {
-    "version": "8.0.303"    
-  }
+    "sdk": {
+      "allowPrerelease": true,
+       "version": "9.0.100-preview.6.24328.19"
+    }
 }

--- a/src/Verifiable.BouncyCastle/packages.lock.json
+++ b/src/Verifiable.BouncyCastle/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "Portable.BouncyCastle": {
         "type": "Direct",
         "requested": "[1.9.0, )",

--- a/src/Verifiable.Core/Assessment/Claim.cs
+++ b/src/Verifiable.Core/Assessment/Claim.cs
@@ -191,7 +191,6 @@ namespace Verifiable.Assessment
         /// <param name="context">Metadata, or context information, associated with the claim.</param>
         public Claim(ClaimId id, ClaimOutcome outcome, ClaimContext context, IReadOnlyList<Claim> subClaims)
         {
-            ArgumentNullException.ThrowIfNull(id);
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(subClaims);
 

--- a/src/Verifiable.Core/Builders/Builder.cs
+++ b/src/Verifiable.Core/Builders/Builder.cs
@@ -49,8 +49,6 @@ namespace Verifiable.Core.Builders
 
         public virtual TResult Build<TSeedParam>(Func<TSeedParam, TResult> seedGenerator, TSeedParam seedGeneratorParameter, Func<TSeedParam, TBuilder, TState> preBuildAction)
         {
-            ArgumentNullException.ThrowIfNull(nameof(seedGenerator));
-
             TState buildInvariant = preBuildAction(seedGeneratorParameter, (TBuilder)this);
 
             TResult seed = seedGenerator(seedGeneratorParameter);

--- a/src/Verifiable.Core/Cryptography/ExactSizeMemoryPool.cs
+++ b/src/Verifiable.Core/Cryptography/ExactSizeMemoryPool.cs
@@ -128,7 +128,6 @@ namespace Verifiable.Core.Cryptography
 
         private void Return(ArraySegment<T> segment, Slab<T> slab)
         {
-            ArgumentNullException.ThrowIfNull(segment);
             ArgumentNullException.ThrowIfNull(slab);
 
             lock(lockObject)

--- a/src/Verifiable.Core/Cryptography/RsaUtilities.cs
+++ b/src/Verifiable.Core/Cryptography/RsaUtilities.cs
@@ -60,11 +60,6 @@ namespace Verifiable.Core.Cryptography
         /// <exception cref="ArgumentOutOfRangeException">The key length mush be either 256 or 512 bytes</exception>.
         public static byte[] Encode(ReadOnlySpan<byte> rsaModulusBytes)
         {
-            if(rsaModulusBytes == null)
-            {
-                throw new ArgumentNullException(nameof(rsaModulusBytes));
-            }
-
             //DID method specifications support only these RSA key lengths at the moment.            
             if(!(rsaModulusBytes.Length == Rsa2048ModulusLength || rsaModulusBytes.Length == Rsa4096ModulusLength))
             {

--- a/src/Verifiable.Core/VerificationMethodConverter.cs
+++ b/src/Verifiable.Core/VerificationMethodConverter.cs
@@ -73,9 +73,6 @@ namespace Verifiable.Core.Did
         /// <param name="typeMap">A runtime map of <see cref="Service"/> and sub-types.</param>
         public VerificationMethodConverter(CryptoSuiteFactoryDelegate cryptoSuiteFactory, ImmutableDictionary<string, Func<string, JsonSerializerOptions, KeyFormat>> typeMap)
         {
-            ArgumentNullException.ThrowIfNull(nameof(typeMap));
-            ArgumentNullException.ThrowIfNull(nameof(cryptoSuiteFactory));
-
             TypeMap = typeMap;
             CryptoSuiteFactory = cryptoSuiteFactory;
         }

--- a/src/Verifiable.Core/packages.lock.json
+++ b/src/Verifiable.Core/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/src/Verifiable.DecentralizedWebNode/packages.lock.json
+++ b/src/Verifiable.DecentralizedWebNode/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "SIL.ReleaseTasks": {
         "type": "Direct",
         "requested": "[2.6.0-beta0030, )",

--- a/src/Verifiable.Jwt/packages.lock.json
+++ b/src/Verifiable.Jwt/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "SIL.ReleaseTasks": {
         "type": "Direct",
         "requested": "[2.6.0-beta0030, )",

--- a/src/Verifiable.Microsoft/packages.lock.json
+++ b/src/Verifiable.Microsoft/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "SIL.ReleaseTasks": {
         "type": "Direct",
         "requested": "[2.6.0-beta0030, )",

--- a/src/Verifiable.NSec/packages.lock.json
+++ b/src/Verifiable.NSec/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "NSec.Cryptography": {
         "type": "Direct",
         "requested": "[24.4.0, )",

--- a/src/Verifiable.Sidetree/packages.lock.json
+++ b/src/Verifiable.Sidetree/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "SIL.ReleaseTasks": {
         "type": "Direct",
         "requested": "[2.6.0-beta0030, )",

--- a/src/Verifiable.Tpm/packages.lock.json
+++ b/src/Verifiable.Tpm/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "Microsoft.TSS": {
         "type": "Direct",
         "requested": "[2.1.1, )",

--- a/src/Verifiable/packages.lock.json
+++ b/src/Verifiable/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "SIL.ReleaseTasks": {
         "type": "Direct",
         "requested": "[2.6.0-beta0030, )",

--- a/test/Verifiable.Benchmarks/packages.lock.json
+++ b/test/Verifiable.Benchmarks/packages.lock.json
@@ -1,22 +1,22 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "BenchmarkDotNet": {
         "type": "Direct",
-        "requested": "[0.13.12, )",
-        "resolved": "0.13.12",
-        "contentHash": "aKnzpUZJJfLBHG7zcfQZhCexZQKcJgElC8qcFUTXPMYFlVauJBobuOmtRnmrapqC2j7EjjZCsPxa3yLvFLx5/Q==",
+        "requested": "[0.14.0, )",
+        "resolved": "0.14.0",
+        "contentHash": "eIPSDKi3oni734M1rt/XJAwGQQOIf9gLjRRKKJ0HuVy3vYd7gnmAIX1bTjzI9ZbAY/nPddgqqgM/TeBYitMCIg==",
         "dependencies": {
-          "BenchmarkDotNet.Annotations": "0.13.12",
+          "BenchmarkDotNet.Annotations": "0.14.0",
           "CommandLineParser": "2.9.1",
           "Gee.External.Capstone": "2.3.0",
           "Iced": "1.17.0",
           "Microsoft.CodeAnalysis.CSharp": "4.1.0",
           "Microsoft.Diagnostics.Runtime": "2.2.332302",
-          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.1.8",
           "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
-          "Perfolizer": "[0.2.1]",
+          "Perfolizer": "[0.3.17]",
           "System.Management": "5.0.0"
         }
       },
@@ -31,8 +31,8 @@
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
-        "resolved": "0.13.12",
-        "contentHash": "4zmFOOJqW1GrEP/t5XKgh97LH9r6zixGy2IA0JAaoTNNnZ8kPBt9u/XagsGNyV0e7rglOpFcWc6wI5EjefKpKA=="
+        "resolved": "0.14.0",
+        "contentHash": "CUDCg6bgHrDzhjnA+IOBl5gAo8Y5hZ2YSs7MBXrYMlMKpBZqrD5ez0537uDveOkcf+YWAoK+S4sMcuWPbIz8bw=="
       },
       "CommandLineParser": {
         "type": "Transitive",
@@ -107,10 +107,11 @@
       },
       "Microsoft.Diagnostics.Tracing.TraceEvent": {
         "type": "Transitive",
-        "resolved": "3.0.2",
-        "contentHash": "Pr7t+Z/qBe6DxCow4BmYmDycHe2MrGESaflWXRcSUI4XNGyznx1ttS+9JNOxLuBZSoBSPTKw9Dyheo01Yi6anQ==",
+        "resolved": "3.1.8",
+        "contentHash": "kl3UMrZKSeSEYZ8rt/GjLUQToREjgQABqfg6PzQBmSlYHTZOKE9ePEOS2xptROQ9SVvngg3QGX51TIT11iZ0wA==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+          "Microsoft.Win32.Registry": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
       "Microsoft.DotNet.PlatformAbstractions": {
@@ -197,11 +198,8 @@
       },
       "Perfolizer": {
         "type": "Transitive",
-        "resolved": "0.2.1",
-        "contentHash": "Dt4aCxCT8NPtWBKA8k+FsN/RezOQ2C6omNGm5o/qmYRiIwlQYF93UgFmeF1ezVNsztTnkg7P5P63AE+uNkLfrw==",
-        "dependencies": {
-          "System.Memory": "4.5.3"
-        }
+        "resolved": "0.3.17",
+        "contentHash": "FQgtCoF2HFwvzKWulAwBS5BGLlh8pgbrJtOp47jyBwh2CW16juVtacN1azOA2BqdrJXkXTNLNRMo7ZlHHiuAnA=="
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/test/Verifiable.Tests/RsaUtilitiesTests.cs
+++ b/test/Verifiable.Tests/RsaUtilitiesTests.cs
@@ -16,7 +16,7 @@ namespace Verifiable.Core
         /// <summary>
         /// Test array that is wrong length for RSA encoding.
         /// </summary>
-        private static byte[] WrongSizeArray1 => Array.Empty<byte>();
+        private static byte[] WrongSizeArray1 => [];
 
         /// <summary>
         /// Test array that is wrong length for RSA encoding.
@@ -28,16 +28,17 @@ namespace Verifiable.Core
         /// </summary>
         public static IEnumerable<object[]> RsaKeySizesInBits => new object[][]
         {
-            new object[] { 2048 },
-            new object[] { 4096 }            
+            [2048],
+            [4096]            
         };
 
 
         [Fact]
         public void EncodeThrowsWithCorrectMessageIfModulusNull()
         {
+            //Since the argument is ReadOnlySpan<byte>, it will be converted to ReadOnlySpan<byte>.Empty automatically.
             const string ParameterName = "rsaModulusBytes";
-            var exception1 = Assert.Throws<ArgumentNullException>(() => RsaUtilities.Encode(null));
+            var exception1 = Assert.Throws<ArgumentOutOfRangeException>(() => RsaUtilities.Encode(null));
             Assert.Equal(ParameterName, exception1.ParamName);
         }
 

--- a/test/Verifiable.Tests/packages.lock.json
+++ b/test/Verifiable.Tests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net8.0": {
+    "net9.0": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.2, )",
@@ -10,22 +10,22 @@
       },
       "dotNetRdf": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "TbaniuT08ZIqRon+vjlFG6+f1Lta1pTftErFR6BrpKetfTg9bI4wwDNcernYswp9q06P2Q58R9HcvDLJxIlUKQ==",
+        "requested": "[3.2.1, )",
+        "resolved": "3.2.1",
+        "contentHash": "WE6sbQtXz5w12V2OpO9BwaVrcIKkSetrFNpl8IcrezluNgZapZAc6MlPLvOvK0YEsGyx1L6ZQnUA7BzJU+Wh0w==",
         "dependencies": {
-          "dotNetRdf.Client": "3.2.0",
-          "dotNetRdf.Core": "3.2.0",
-          "dotNetRdf.Data.DataTables": "3.2.0",
-          "dotNetRdf.Dynamic": "3.2.0",
-          "dotNetRdf.Inferencing": "3.2.0",
-          "dotNetRdf.Ldf": "3.2.0",
-          "dotNetRdf.Ontology": "3.2.0",
-          "dotNetRdf.Query.FullText": "3.2.0",
-          "dotNetRdf.Query.Spin": "3.2.0",
-          "dotNetRdf.Shacl": "3.2.0",
-          "dotNetRdf.Skos": "3.2.0",
-          "dotNetRdf.Writing.HtmlSchema": "3.2.0"
+          "dotNetRdf.Client": "3.2.1",
+          "dotNetRdf.Core": "3.2.1",
+          "dotNetRdf.Data.DataTables": "3.2.1",
+          "dotNetRdf.Dynamic": "3.2.1",
+          "dotNetRdf.Inferencing": "3.2.1",
+          "dotNetRdf.Ldf": "3.2.1",
+          "dotNetRdf.Ontology": "3.2.1",
+          "dotNetRdf.Query.FullText": "3.2.1",
+          "dotNetRdf.Query.Spin": "3.2.1",
+          "dotNetRdf.Shacl": "3.2.1",
+          "dotNetRdf.Skos": "3.2.1",
+          "dotNetRdf.Writing.HtmlSchema": "3.2.1"
         }
       },
       "FsCheck.Xunit": {
@@ -40,9 +40,9 @@
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "XHeSTfBj6/kLNcfbOoaoVogamaOcKXOENQ3epo616EjnnGJHFNzuNFI6TGXgL+lYwtX4E8cpCGu6UfhYrOtHGQ=="
+        "requested": "[4.0.254, )",
+        "resolved": "4.0.254",
+        "contentHash": "vsLyzXbjfZf+bGsL7FYhdWy+F0VgKT7vchkgR8bcTSdGwNhJs8sImF10niy78xZDZ43i22WPgmxSS2+FQ/V6PA=="
       },
       "LiquidTestReports.Markdown": {
         "type": "Direct",
@@ -172,16 +172,16 @@
       },
       "dotNetRdf.Client": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "Co2VTMjv/HpLC/onQbzyxGYGFCxx/Z/Nz0stWXPjjKolZVPQaZbYXrareql78PuYAuaHk5LoaIC2DbW+eUexTQ==",
+        "resolved": "3.2.1",
+        "contentHash": "oBK2u4AY80iLAviAZsJBM4VSOvwxnAWYlBKX/qnieb2K9mjFqGbVx/hquvNJvV28yDwONImhFVA6Je17ypJisA==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Core": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "RnIzoYZ7YhsyLJn8F6fDhY9QxIaLkdcN+uAc3NmvFnOOwsxHkZnbXGAnEIkCcZAVvciM5eybshKJenizYlQvnw==",
+        "resolved": "3.2.1",
+        "contentHash": "xDcDDIny+W5Fx2g8PcLAOvzqNWEov7L5TcEraq6bxIZKae2Rh0eEieLDQP/B6aSFUnmHWaimDJ89DP2wJIKAQw==",
         "dependencies": {
           "AngleSharp": "1.1.2",
           "HtmlAgilityPack": "1.11.61",
@@ -199,88 +199,88 @@
       },
       "dotNetRdf.Data.DataTables": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "V/73t33KldmGmwIC8ECTtbPQp9SrIL9UkxdMlqyGb6HR9HJ4D4DbDgQAy76pMr3cnNB/jNljc3FMMuu7E3TQiQ==",
+        "resolved": "3.2.1",
+        "contentHash": "swIpOAfcwU3/IpadCkLerVFFuik3irI3QpWC3FBxKIfuGrd6CJTTQwtQg0mEWpzXhVUTMocldpxmf5oC7UG5tA==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Dynamic": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "kaz2D71o+T5RxdlHk8GVvs1UjilQ/JF/F7uSBeOOTWOUZOM3ePLJXJgMrIWAy6R/FI+HCG4VC+oHSlMr2mEakQ==",
+        "resolved": "3.2.1",
+        "contentHash": "4OpKBG29ILjqUK0T5FvN6FI483DdDKXZ//Xqj0qnRY6Qf2iseLB/cNGTUm5vNIQ9tQTX91RPfPKjRJmwhRGx1w==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Inferencing": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "Ac+qgnUQKupm51w3AwnLNkgCDRNwqK7lOR9JhYUdRFkHGzSwZmEEyvmMLvBh2VtUL1O7HmLDSUIkWUPmtRsNUA==",
+        "resolved": "3.2.1",
+        "contentHash": "J0y2qxS66gHa8GDQiSpJXLKQ+VMGLdWwmGsi108Ie5C43oKo70VVVkEiuTDXShY2G/xVaoX7eorx53Kt5OknIg==",
         "dependencies": {
-          "dotNetRdf.Ontology": "3.2.0"
+          "dotNetRdf.Ontology": "3.2.1"
         }
       },
       "dotNetRdf.Ldf": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "WtCInkHP06KevnBOBFFhEkUMlPMXTEQlF6pqD0GOVaH8soOHYqDWZ/DvimaUng1LZy8Tqm9RPojZr8KguN/JNw==",
+        "resolved": "3.2.1",
+        "contentHash": "CWyDUQFm7o7t8CEPMYJNw1Xu9X5hDaSgTIeIrP/VAyROQ0XnW+J00ODn3omvtUr2NdHPy+Fdtedmh2Hg3GctEw==",
         "dependencies": {
           "Resta.UriTemplates": "1.4.0",
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Ontology": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "E2R2f/lDeqHWbZ3HbrT/RcyrqHmA/cj6paXzxxfIkZoDNrWWaXKZ2dm0KK0zUga9k6jSVOLjQkoDp+f6RXC/0g==",
+        "resolved": "3.2.1",
+        "contentHash": "jYF76TzEMASXrBuYCpuLc/j607UpZdpFlyget7eofvnyLQzKaxm60NNTTdGmLVz0vYVU2szAYZJktgKr/O6xHQ==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Query.FullText": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "CZ/mbdxskg2kNTfD8WOiMyDLFGMM/26U3C/W703bT8ffstH6k7yQ9dE25l0Hb78kfcgWzTrJ6rp3CW8Bkcf+fg==",
+        "resolved": "3.2.1",
+        "contentHash": "22EGhShzYZhxjvIYe46IeP9i+ssBmR34UlGP7eM5FbS6R2yvCRXceTlwmhrbHv9ZNjf449aGVJFPJVwo9I9gEQ==",
         "dependencies": {
           "Lucene.Net": "4.8.0-beta00016",
           "Lucene.Net.QueryParser": "4.8.0-beta00016",
           "SharpZipLib": "1.4.2",
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Query.Spin": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "sqEo6BR8WwNm81bckMTqHyDoF5oT88UN+nvkadBrvz7ZbOq6kdUKx2WSl22n24h/WLLMuJEDzwJ/kCEVrO5A9g==",
+        "resolved": "3.2.1",
+        "contentHash": "udOjJH0sNs2bAgx2S8ObecsilqsWS7cU8R0DjxnzFjxWYRHCLt5Pnh2/UzDe6Q6GiYdKXUVjC1kYdp6EfXx3DA==",
         "dependencies": {
           "System.Runtime": "4.3.1",
-          "dotNetRdf.Core": "3.2.0",
-          "dotNetRdf.Inferencing": "3.2.0"
+          "dotNetRdf.Core": "3.2.1",
+          "dotNetRdf.Inferencing": "3.2.1"
         }
       },
       "dotNetRdf.Shacl": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "IAbwY7TPAC0rXosuCX4jGhqndcoW+nBj12X0zUZs3tTY0jl22sH69g4dNMqfXKn1H5hWHEf0BncrS6EOSe3Geg==",
+        "resolved": "3.2.1",
+        "contentHash": "9Tlm5oJjzEDNbrS+5lOad+DODh1noYoaTLh0aKNiosD55xurbctWpvTcqR1skmeFuQm/ihYUcpq3WUCSZbc8Kw==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Skos": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "ImN4cBEe85Iffl1QW50HQ0epphpOV7WTCaedMvc/TWgUigQtBVxtI9Qnn9MKU4Xwr9yRWrrLGZdrhXVgEA+p9g==",
+        "resolved": "3.2.1",
+        "contentHash": "8lqiIjLToMJUHtEx0CiLZwqG/UFmYgUPh0KTlohX3pDU1GaUdaNLU7LRheDdaZUb9UzN5dnWHL/E8NWIaEZ4xw==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "dotNetRdf.Writing.HtmlSchema": {
         "type": "Transitive",
-        "resolved": "3.2.0",
-        "contentHash": "4zWbNnRw6SpDzkWM/8gKO5jcKW6UQWcJ+riscZxUDeowZuJCdAzy5AFBAqbaP+UC2EKcE5OB0t83GiIC/E/acw==",
+        "resolved": "3.2.1",
+        "contentHash": "hJr0qwrkiXiLhL/86gR8QF9N4QT03eUyXoIomD5M0nT1CxaQzVOHyRRq1Mew8WVFw03iYdIU/aiHOBLme89k7g==",
         "dependencies": {
-          "dotNetRdf.Core": "3.2.0"
+          "dotNetRdf.Core": "3.2.1"
         }
       },
       "FsCheck": {


### PR DESCRIPTION
- Update to .NET 9.
- Use C# 13.0 (preview).
- Update NuGet packages.
- Fix compiler errors due to updates.