### PR TITLE
Replace Spectre with System.CommandLine, add MCP

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
       # Do nothing temporarily.
       # - name: Update diagram

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,14 +91,14 @@ jobs:
     steps:
     - name: Harden Runner
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2
+      uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76
       with:
         disable-sudo: true
         egress-policy: block
         allowed-endpoints: ${{ env.COMMON_ALLOWED_ENDPOINTS }}
 
     - name: Checkout code
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -119,7 +119,7 @@ jobs:
       run: dotnet restore --locked-mode
 
     - name: Cache local .NET tools
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
       with:
         path: ~/.dotnet/tools
         key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}
@@ -191,7 +191,7 @@ jobs:
 
     #- name: Upload Stryker output artefacts
     #  if: ${{ matrix.os == 'ubuntu-latest' }}
-    #  uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+    #  uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
     #  with:
     #    name: 'Stryker output artefacts'
     #    path: ${{ github.workspace }}/StrykerOutput/
@@ -200,7 +200,7 @@ jobs:
     #  run: dotnet publish -c Release --verbosity normal -o ./publish/
 
     # - name: Archive publish results
-    #  uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+    #  uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
     #  with:
     #    name: Verifiable.Benchmarks
     #    path: ./publish/*
@@ -209,7 +209,7 @@ jobs:
     #  run: dotnet "./publish/Verifiable.Benchmarks.dll" -f "Verifiable.Benchmarks.*"
 
     # - name: Upload benchmark results
-    #  uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+    #  uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
     #  with:
     #    name: Benchmark_Results
     #    path: ./BenchmarkDotNet.Artifacts/results/*
@@ -232,6 +232,13 @@ jobs:
         header: Report
         path: '${{ github.workspace }}/reports/coverage/Summary.md'
         recreate: true
+
+    - name: Update MCP server manifest version
+      if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' }}
+      run: |
+        sed -i 's/"version": "[^"]*"/"version": "'"${VERSION%%+*}"'"/' src/Verifiable/.mcp/server.json
+        echo "Updated server.json version to: ${VERSION%%+*}"
+        cat src/Verifiable/.mcp/server.json
 
     - name: Pack NuGet packages
       if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' }}
@@ -263,7 +270,7 @@ jobs:
 
     - name: Upload Verifiable NuGet packages
       if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' && github.actor != 'dependabot[bot]' }}
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         name: nupkg
         path: ./nupkgs/*.*
@@ -279,14 +286,14 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Harden Runner
-          uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2
+          uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76
           with:
             disable-sudo: true
             egress-policy: block
             allowed-endpoints: ${{ env.COMMON_ALLOWED_ENDPOINTS }}
 
         - name: Download NuGet artifacts
-          uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+          uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
           with:
             name: nupkg
 
@@ -303,14 +310,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76
         with:
           disable-sudo: true
           egress-policy: audit
           allowed-endpoints: ${{ env.COMMON_ALLOWED_ENDPOINTS }}
 
       - name: Download NuGet artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: nupkg
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,14 +15,15 @@
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
     <PackageVersion Include="SIL.ReleaseTasks" Version="3.1.1" />
     <PackageVersion Include="SimpleBase" Version="5.6.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.0-preview.1.25080.5" />
-    <PackageVersion Include="System.Net.Http.Json" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.1" />
+    <PackageVersion Include="System.Net.Http.Json" Version="10.0.1" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.1" />
     <PackageVersion Include="WinSharpFuzz" Version="1.0.0" />
-    <PackageVersion Include="CsCheck" Version="4.4.1" />
-    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.4" />
+    <PackageVersion Include="CsCheck" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -20,7 +20,7 @@
       <certificate fingerprint="5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-      <owners>rsuter;patrik;wtfsck;alirezanet;danielpalme;stryker-mutator;MarkZither;AnthonyLloyd;pshkarin;Microsoft;9ee1;commandlineparser;DotLiquid;roastedamoeba;NightOwl888;FlorianRappl;wtfsck;zzzprojects;SharpDevelop;jedisct1;xoofx;ApacheLuceneNet;tssdotmsr;Microsoft;dotnetfoundation;albi05;jd.cain.jr;joelhulen;aarnott;AndreyAkinshin;dotnetrdf;kurt;codito;kurtmkurtm;nsec;clairernovotny;Metalnem;sil-lsdev;sedatk;spectresystems;winsharpfuzz;</owners>
+      <owners>ModelContextProtocol;ModelContextProtocolOfficial;rsuter;patrik;wtfsck;alirezanet;danielpalme;stryker-mutator;MarkZither;AnthonyLloyd;pshkarin;Microsoft;9ee1;commandlineparser;DotLiquid;roastedamoeba;NightOwl888;FlorianRappl;wtfsck;zzzprojects;SharpDevelop;jedisct1;xoofx;ApacheLuceneNet;tssdotmsr;Microsoft;dotnetfoundation;albi05;jd.cain.jr;joelhulen;aarnott;AndreyAkinshin;dotnetrdf;kurt;codito;kurtmkurtm;nsec;clairernovotny;Metalnem;sil-lsdev;sedatk;spectresystems;winsharpfuzz;</owners>
     </repository>
   </trustedSigners>
 </configuration>

--- a/src/Verifiable.BouncyCastle/packages.lock.json
+++ b/src/Verifiable.BouncyCastle/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "Portable.BouncyCastle": {
         "type": "Direct",

--- a/src/Verifiable.Core/Result.cs
+++ b/src/Verifiable.Core/Result.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Verifiable.Core;
+
+/// <summary>
+/// Factory methods for creating <see cref="Result{TValue, TError}"/> instances.
+/// </summary>
+public static class Result
+{
+    /// <summary>
+    /// Creates a successful result with the specified value.
+    /// </summary>
+    public static Result<TValue, TError> Success<TValue, TError>(TValue value) =>
+        Result<TValue, TError>.Success(value);
+
+    /// <summary>
+    /// Creates a failed result with the specified error.
+    /// </summary>
+    public static Result<TValue, TError> Failure<TValue, TError>(TError error) =>
+        Result<TValue, TError>.Failure(error);    
+}
+
+/// <summary>
+/// Represents the result of an operation that can succeed with a value or fail with an error.
+/// </summary>
+/// <typeparam name="TValue">The type of the success value.</typeparam>
+/// <typeparam name="TError">The type of the error.</typeparam>
+public readonly struct Result<TValue, TError>: IEquatable<Result<TValue, TError>>
+{
+    /// <summary>
+    /// Assigned value if the operation succeeded.
+    /// </summary>
+    private readonly TValue? _value;
+
+    /// <summary>
+    /// Assigned value if the operation failed.
+    /// </summary>
+    private readonly TError? _error;
+
+
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(Value))]
+    [MemberNotNullWhen(false, nameof(Error))]
+    public bool IsSuccess { get; }
+
+
+    /// <summary>
+    /// Gets the success value. Only valid when <see cref="IsSuccess"/> is true.
+    /// </summary>
+    public TValue? Value => _value;
+
+
+    /// <summary>
+    /// Gets the error. Only valid when <see cref="IsSuccess"/> is false.
+    /// </summary>
+    public TError? Error => _error;
+
+
+    /// <summary>
+    /// A private constructor to initialize the result.
+    /// </summary>
+    /// <param name="isSuccess">If true, the operation succeeded.</param>
+    /// <param name="value">The success value.</param>
+    /// <param name="error">The error value.</param>
+    private Result(bool isSuccess, TValue? value, TError? error)
+    {
+        IsSuccess = isSuccess;
+        _value = value;
+        _error = error;
+    }
+
+
+    /// <summary>
+    /// Creates a successful result with the specified value.
+    /// </summary>
+    public static Result<TValue, TError> Success(TValue value) => new(true, value, default);
+
+    
+    /// <summary>
+    /// Creates a failed result with the specified error.
+    /// </summary>
+    public static Result<TValue, TError> Failure(TError error) => new(false, default, error);
+
+
+    /// <summary>
+    /// Executes one of the provided functions based on whether the result is success or failure.
+    /// </summary>
+    public TResult Match<TResult>(Func<TValue, TResult> onSuccess, Func<TError, TResult> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+
+        return IsSuccess ? onSuccess(_value!) : onFailure(_error!);
+    }
+
+
+    /// <summary>
+    /// Transforms the success value using the specified function.
+    /// </summary>
+    public Result<TNewValue, TError> Map<TNewValue>(Func<TValue, TNewValue> map)
+    {
+        ArgumentNullException.ThrowIfNull(map);
+
+        return IsSuccess
+            ? Result<TNewValue, TError>.Success(map(_value!))
+            : Result<TNewValue, TError>.Failure(_error!);
+    }
+
+
+    /// <summary>
+    /// Chains another operation that returns a Result.
+    /// </summary>
+    public Result<TNewValue, TError> Bind<TNewValue>(Func<TValue, Result<TNewValue, TError>> bind)
+    {
+        ArgumentNullException.ThrowIfNull(bind);
+
+        return IsSuccess ? bind(_value!) : Result<TNewValue, TError>.Failure(_error!);
+    }
+
+
+    /// <inheritdoc />
+    public bool Equals(Result<TValue, TError> other) =>
+        IsSuccess == other.IsSuccess &&
+        EqualityComparer<TValue?>.Default.Equals(_value, other._value) &&
+        EqualityComparer<TError?>.Default.Equals(_error, other._error);
+
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Result<TValue, TError> other && Equals(other);
+
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(IsSuccess, _value, _error);
+
+
+    public static bool operator ==(Result<TValue, TError> left, Result<TValue, TError> right) => left.Equals(right);
+
+
+    public static bool operator !=(Result<TValue, TError> left, Result<TValue, TError> right) => !left.Equals(right);
+
+
+    /// <summary>
+    /// Implicitly converts a value to a successful Result.
+    /// </summary>
+    public static implicit operator Result<TValue, TError>(TValue value) => Success(value);
+}

--- a/src/Verifiable.Core/packages.lock.json
+++ b/src/Verifiable.Core/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/src/Verifiable.DecentralizedWebNode/packages.lock.json
+++ b/src/Verifiable.DecentralizedWebNode/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/src/Verifiable.Jwt/packages.lock.json
+++ b/src/Verifiable.Jwt/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/src/Verifiable.Microsoft/packages.lock.json
+++ b/src/Verifiable.Microsoft/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/src/Verifiable.NSec/packages.lock.json
+++ b/src/Verifiable.NSec/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "NSec.Cryptography": {
         "type": "Direct",

--- a/src/Verifiable.Sidetree/packages.lock.json
+++ b/src/Verifiable.Sidetree/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/src/Verifiable.Tpm/packages.lock.json
+++ b/src/Verifiable.Tpm/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "Microsoft.TSS": {
         "type": "Direct",

--- a/src/Verifiable/.mcp/server.json
+++ b/src/Verifiable/.mcp/server.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.lumoin/verifiable",
+    "description": "Tools for DIDs (Decentralized Identifiers), Verifiable Credentials, and TPM",
+    "version": "1.0.0",
+    "repository": {
+        "url": "https://github.com/lumoin/verifiable",
+        "source": "github"
+    },
+    "packages": [
+        {
+            "registryType": "nuget",
+            "identifier": "Verifiable",
+            "transport": {
+                "type": "stdio"
+            },
+            "packageArguments": [
+                {
+                    "type": "positional",
+                    "value": "-mcp",
+                    "valueHint": "mcp_flag"
+                }
+            ]
+        }
+    ]
+}

--- a/src/Verifiable/McpToolNames.cs
+++ b/src/Verifiable/McpToolNames.cs
@@ -1,0 +1,57 @@
+﻿namespace Verifiable;
+
+/// <summary>
+/// Constants for MCP tool names exposed by the Verifiable MCP server.
+/// These names are used for tool registration and can be referenced in documentation.
+/// </summary>
+public static class McpToolNames
+{
+    /// <summary>
+    /// Gets TPM (Trusted Platform Module) information from the current system.
+    /// </summary>
+    public const string GetTpmInfo = "GetTpmInfo";
+
+    /// <summary>
+    /// Saves TPM information to a JSON file on disk.
+    /// </summary>
+    public const string SaveTpmInfoToFile = "SaveTpmInfoToFile";
+
+    /// <summary>
+    /// Checks if the current platform supports TPM.
+    /// </summary>
+    public const string CheckTpmSupport = "CheckTpmSupport";
+
+    /// <summary>
+    /// Creates a new DID (Decentralized Identifier) document.
+    /// </summary>
+    public const string CreateDid = "CreateDid";
+
+    /// <summary>
+    /// Revokes an existing DID document.
+    /// </summary>
+    public const string RevokeDid = "RevokeDid";
+
+    /// <summary>
+    /// Lists all DID documents.
+    /// </summary>
+    public const string ListDids = "ListDids";
+
+    /// <summary>
+    /// Views a specific DID document.
+    /// </summary>
+    public const string ViewDid = "ViewDid";
+
+    /// <summary>
+    /// All available tool names.
+    /// </summary>
+    public static readonly string[] All =
+    [
+        GetTpmInfo,
+        SaveTpmInfoToFile,
+        CheckTpmSupport,
+        CreateDid,
+        RevokeDid,
+        ListDids,
+        ViewDid
+    ];
+}

--- a/src/Verifiable/Verifiable.csproj
+++ b/src/Verifiable/Verifiable.csproj
@@ -10,27 +10,34 @@
     <Description>A command line tool for system security elements, decentralized identifiers and verifiable credentials.</Description>
     <PackageTags>ssi wallet tpm2 trusted-platform-module eidas did self-sovereign-identity verifiable-credentials decentralized-identifiers</PackageTags>
     <ApplicationIcon>resources/verifiable-nuget-logo.ico</ApplicationIcon>
-  </PropertyGroup>
 
-  <!--
-  https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
-  <PropertyGroup>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimmerDefaultAction>link</TrimmerDefaultAction>
+    <TrimMode>full</TrimMode>
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+
+    <!-- Allow build to succeed despite TSS.Net trim warnings. -->
+    <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
   </PropertyGroup>
-  -->
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" />
-    <PackageReference Include="Spectre.Console.Cli" />
+    <None Include=".mcp\server.json" Pack="true" PackagePath=".mcp" />
+  </ItemGroup>
+
+  <!-- TSS.Net is not trim-compatible; exclude from trimming until replaced. -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="TSS.Net" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Verifiable.Tpm\Verifiable.Tpm.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-
+    <ProjectReference Include="..\Verifiable.Core\Verifiable.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Verifiable/VerifiableJsonContext.cs
+++ b/src/Verifiable/VerifiableJsonContext.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+using Verifiable.Tpm;
+
+namespace Verifiable;
+
+/// <summary>
+/// Source-generated JSON serialization context for AOT/trimming compatibility.
+/// The source generator walks the type graph from TpmInfo to handle all nested types.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,WriteIndented = true)]
+[JsonSerializable(typeof(TpmInfo))]
+internal partial class VerifiableJsonContext: JsonSerializerContext;

--- a/src/Verifiable/VerifiableMcpServer.cs
+++ b/src/Verifiable/VerifiableMcpServer.cs
@@ -1,0 +1,81 @@
+﻿using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Verifiable;
+
+/// <summary>
+/// MCP Server tools for Verifiable functionality.
+/// These tools are exposed to AI clients like GitHub Copilot when running in MCP mode.
+/// </summary>
+[McpServerToolType]
+public sealed class VerifiableMcpServer
+{
+    [McpServerTool(Name = McpToolNames.GetTpmInfo), Description("Get TPM (Trusted Platform Module) information from the current system. Returns JSON with TPM details or an error if TPM is not supported.")]
+    public static string GetTpmInfo()
+    {
+        var result = VerifiableOperations.GetTpmInfoAsJson();
+
+        return result.IsSuccess ? result.Value! : result.Error!;
+    }
+
+
+    [McpServerTool(Name = McpToolNames.SaveTpmInfoToFile), Description("Save TPM information to a JSON file on disk.")]
+    public static async Task<string> SaveTpmInfoToFile(
+        [Description("The file path where to save the TPM information JSON. Defaults to 'tpm_data.json' if not specified.")] string? filePath = null)
+    {
+        var result = await VerifiableOperations.SaveTpmInfoToFileAsync(filePath);
+
+        return result.IsSuccess
+            ? $"TPM information saved to '{result.Value}'."
+            : result.Error!;
+    }
+
+
+    [McpServerTool(Name = McpToolNames.CheckTpmSupport), Description("Check if the current platform supports TPM (Trusted Platform Module).")]
+    public static string CheckTpmSupport()
+    {
+        return VerifiableOperations.CheckTpmSupportMessage();
+    }
+
+
+    [McpServerTool(Name = McpToolNames.CreateDid), Description("Create a new DID (Decentralized Identifier) document.")]
+    public static string CreateDid(
+        [Description("The unique identifier for the new DID document.")] int id,
+        [Description("A parameter for the DID document.")] string param,
+        [Description("An optional extra parameter.")] string? extraParam = null)
+    {
+        var result = VerifiableOperations.CreateDid(id, param, extraParam);
+
+        return result.Value!;
+    }
+
+
+    [McpServerTool(Name = McpToolNames.RevokeDid), Description("Revoke an existing DID (Decentralized Identifier) document.")]
+    public static string RevokeDid(
+        [Description("The identifier of the DID document to revoke.")] int id)
+    {
+        var result = VerifiableOperations.RevokeDid(id);
+
+        return result.Value!;
+    }
+
+
+    [McpServerTool(Name = McpToolNames.ListDids), Description("List all DID (Decentralized Identifier) documents.")]
+    public static string ListDids()
+    {
+        var result = VerifiableOperations.ListDids();
+
+        return result.Value!;
+    }
+
+
+    [McpServerTool(Name = McpToolNames.ViewDid), Description("View a specific DID (Decentralized Identifier) document.")]
+    public static string ViewDid(
+        [Description("The identifier of the DID document to view.")] int id)
+    {
+        var result = VerifiableOperations.ViewDid(id);
+
+        return result.Value!;
+    }
+}

--- a/src/Verifiable/VerifiableOperations.cs
+++ b/src/Verifiable/VerifiableOperations.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Verifiable.Core;
+using Verifiable.Tpm;
+
+namespace Verifiable;
+
+/// <summary>
+/// Shared operations for DID, VC, and TPM functionality.
+/// Used by both CLI commands and MCP tools.
+/// </summary>
+public static class VerifiableOperations
+{
+    public static bool IsTpmSupported() => TpmExtensions.IsTpmPlatformSupported();
+
+    public static string GetPlatformDescription() => RuntimeInformation.OSDescription;
+
+
+    public static Result<string, string> GetTpmInfoAsJson()
+    {
+        if(!IsTpmSupported())
+        {
+            return Result.Failure<string, string>(
+                $"Trusted platform module (TPM) information is not supported on {GetPlatformDescription()}.");
+        }
+
+        try
+        {
+            var tpm = new TpmWrapper();
+            var tpmInfo = TpmExtensions.GetAllTpmInfo(tpm.Tpm);
+            string json = JsonSerializer.Serialize(tpmInfo, VerifiableJsonContext.Default.TpmInfo);
+
+            return Result.Success<string, string>(json);
+        }
+        catch(Exception ex)
+        {
+            return Result.Failure<string, string>($"Error retrieving TPM information: {ex.Message}");
+        }
+    }
+
+
+    public static async Task<Result<string, string>> SaveTpmInfoToFileAsync(string? filePath = null)
+    {
+        if(!IsTpmSupported())
+        {
+            return Result.Failure<string, string>(
+                $"Trusted platform module (TPM) information is not supported on {GetPlatformDescription()}.");
+        }
+
+        try
+        {
+            var tpm = new TpmWrapper();
+            var tpmInfo = TpmExtensions.GetAllTpmInfo(tpm.Tpm);
+
+            string targetPath = filePath ?? "tpm_data.json";
+            await using var stream = new FileStream(targetPath, FileMode.Create, FileAccess.Write);
+            await JsonSerializer.SerializeAsync(stream, tpmInfo, VerifiableJsonContext.Default.TpmInfo);
+
+            return Result.Success<string, string>(Path.GetFullPath(targetPath));
+        }
+        catch(Exception ex)
+        {
+            return Result.Failure<string, string>($"Error saving TPM information: {ex.Message}");
+        }
+    }
+
+
+    public static string CheckTpmSupportMessage()
+    {
+        bool isSupported = IsTpmSupported();
+        string os = GetPlatformDescription();
+
+        return isSupported
+            ? $"TPM is supported on this platform ({os})."
+            : $"TPM is NOT supported on this platform ({os}).";
+    }
+
+
+    public static Result<string, string> CreateDid(int id, string param, string? extraParam = null)
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"Created DID document with ID: {id}");
+        result.AppendLine($"Parameter: {param}");
+
+        if(!string.IsNullOrEmpty(extraParam))
+        {
+            result.AppendLine($"Extra parameter: {extraParam}");
+        }
+
+        //TODO: Implement actual DID creation logic.
+        result.AppendLine("Note: This is a placeholder. Actual DID creation is not yet implemented.");
+
+        return Result.Success<string, string>(result.ToString());
+    }
+
+
+    public static Result<string, string> RevokeDid(int id)
+    {
+        //TODO: Implement actual DID revocation logic.
+        return Result.Success<string, string>(
+            $"Revoked DID document with ID: {id}\nNote: This is a placeholder. Actual DID revocation is not yet implemented.");
+    }
+
+
+    public static Result<string, string> ListDids()
+    {
+        //TODO: Implement actual DID listing logic.
+        return Result.Success<string, string>(
+            "Listing all DID documents.\nNote: This is a placeholder. Actual DID listing is not yet implemented.");
+    }
+
+
+    public static Result<string, string> ViewDid(int id)
+    {
+        //TODO: Implement actual DID viewing logic.
+        return Result.Success<string, string>(
+            $"Viewing DID document with ID: {id}\nNote: This is a placeholder. Actual DID viewing is not yet implemented.");
+    }
+}

--- a/src/Verifiable/packages.lock.json
+++ b/src/Verifiable/packages.lock.json
@@ -2,11 +2,57 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "0jjfjQSOFZlHhwOoIQw0WyzxtkDMYdnPY3iFrOLasxYq/5J4FDt1HWT8TktBclOVjFY1FOOkoOc99X7AhbqSIw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.1",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Json": "10.0.1",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Diagnostics": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.1",
+          "Microsoft.Extensions.Logging.Console": "10.0.1",
+          "Microsoft.Extensions.Logging.Debug": "10.0.1",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.1",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
+      },
+      "ModelContextProtocol": {
+        "type": "Direct",
+        "requested": "[0.5.0-preview.1, )",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "QJpuNEnMZLJmvASbZ2nvMqENTZk3HYF83IihoHs3EJ5vTlz4sYjji9bXh2HP5UxpXIdHGn0iuHu0X2Tpq2zilw==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "ModelContextProtocol.Core": "0.5.0-preview.1"
+        }
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",
@@ -17,25 +63,295 @@
           "Markdig.Signed": "0.37.0"
         }
       },
-      "Spectre.Console": {
+      "System.CommandLine": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
-      },
-      "Spectre.Console.Cli": {
-        "type": "Direct",
-        "requested": "[0.53.1, )",
-        "resolved": "0.53.1",
-        "contentHash": "y//7ZZ0shhvgXzoJXJzMaLGA4dPem8qCbkyv9khfE8NQDlH4hPVsHOHYoz6uzAwiTX9Yd7OnX3wNOX/wRfPUOg==",
-        "dependencies": {
-          "Spectre.Console": "0.53.1"
-        }
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "GLc43eDFq8KbpxIb7UhTwV0vC5CzB0NspJvfFbfhoW4O057xCJXuO18KLpVn9x3JykQn2mRske6+I6JXHwqmDg=="
       },
       "Markdig.Signed": {
         "type": "Transitive",
         "resolved": "0.37.0",
         "contentHash": "J7Mt1QjKijE7aAK81u5nt4SYPYEvt1odfr4ddMvyOscyNT3PoGfHKKTBB5VBSXJrWZWhfJlcG7hHBLiqawg+nw=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "PHeuDm2tC6wJPEQvleUr2kNQaIMNqSf3aEbzkIPlZyQ0+0SYI9SwXVLdGD1NPBI+xB+Vb2lxZKhrFlIf9kP9WA=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Lp4CZIuTVXtlvkAnTq6QvMSW7+H62gX2cU2vdFxHQUxvrWTpi7LwYI3X+YAyIS0r12/p7gaosco7efIxL4yFNw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "s5cxcdtIig66YT3J+7iHflMuorznK8kXuwBBPHMp4KImx5ZGE3FRa1Nj9fI/xMwFV+KzUMjqZ2MhOedPH8LiBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "csD8Eps3HQ3yc0x6NhgTV+aIFKSs3qVlVCtFnMHz/JOjnv7eEj/qSXKXiK9LzBzB1qSfAVqFnB5iaX2nUmagIQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "N/6GiwiZFCBFZDk3vg1PhHW3zMqqu5WWpmeZAA9VTXv7Q8pr8NZR/EQsH0DjzqydDksJtY6EQBsu81d5okQOlA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "0zW3eYBJlRctmgqk5s0kFIi5o5y2g80mvGCD8bkYxREPQlKUnr0ndU/Sop+UDIhyWN0fIi4RW63vo7BKTi7ncA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "ULEJ0nkaW90JYJGkFujPcJtADXcJpXiSOLbokPcWJZ8iDbtDINifEYAUVqZVr81IDNTrRFul6O8RolOKOsgFPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Json": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YaocqxscJLxLit0F5yq2XyB+9C7rSRfeTL7MJIl7XwaOoUO3i0EqfO2kmtjiRduYWw7yjcSINEApYZbzjau2gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "QMoMrkNpnQym5mpfdxfxpRDuqLpsOuztguFvzH9p+Ex+do+uLFoi7UkAsBO4e9/tNR3eMFraFf2fOAi2cp3jjA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "+b3DligYSZuoWltU5YdbMpIEUHNZPgPrzWfNiIuDkMdqOl93UxYB5KzS3lgpRfTXJhTNpo/CZ8w/sTkDTPDdxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "4bxzGXIzZnz0Bf7czQ72jGvpOqJsRW/44PS7YLFXTTnu6cNcPvmSREDvBoH0ZVP2hAbMfL4sUoCUn54k70jPWw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "49dFvGJjLSwGn76eHnP1gBvCJkL8HRYpCrG0DCvsP6wRpEQRLN2Fq8rTxbP+6jS7jmYKCnSVO5C65v4mT3rzeA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "qmoQkVZcbm4/gFpted3W3Y+1kTATZTcUhV3mRkbtpfBXlxWCHwh/2oMffVcCruaGOfJuEnyAsGyaSUouSdECOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "9ItMpMLFZFJFqCuHLLbR3LiA4ahA8dMtYuXpXl2YamSDWZhYS9BruPprkftY0tYi2bQ0slNrixdFm+4kpz1g5w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Zg8LLnfZs5o2RCHD/+9NfDtJ40swauemwCa7sI8gQoAye/UJHRZNpCtC7a5XE7l9Z7mdI8iMWnLZ6m7Q6S3jLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "38Q8sEHwQ/+wVO/mwQBa0fcdHbezFpusHE+vBw/dSr6Fq/kzZm3H/NQX511Jki/R3FHd64IY559gdlHZQtYeEA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "VqfTvbX9C6BA0VeIlpzPlljnNsXxiI5CdUHb9ksWERH94WQ6ft3oLGUAa4xKcDGu4xF+rIZ8wj7IOAd6/q7vGw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Zp9MM+jFCa7oktIug62V9eNygpkf+6kFVatF+UC/ODeUwIr5givYKy8fYSSI9sWdxqDqv63y1x0mm2VjOl8GOw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "System.Diagnostics.EventLog": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "WnFvZP+Y+lfeNFKPK/+mBpaCC7EeBDlobrQOqnP7rrw/+vE7yu8Rjczum1xbC0F/8cAHafog84DMp9200akMNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "G6VVwywpJI4XIobetGHwg7wDOYC2L2XBYdtskxLaKF/Ynb5QBwLl7Q//wxAR2aVCLkMpoQrjSP9VoORkyddsNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "pL78/Im7O3WmxHzlKUsWTYchKL881udU7E26gCD3T0+/tPhWVfjPwMzfN/MRKU7aoFYcOiqcG2k1QTlH5woWow==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "ModelContextProtocol.Core": {
+        "type": "Transitive",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "33V1Druluweou6x2LN6MSMbhiwHOYZxTUEJ1okFKjYDRIthctTVe0EJi//nifl4MRld2b5D5LnuV9sezz54p6g==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "xfaHEHVDkMOOZR5S6ZGezD0+vekdH1Nx/9Ih8/rOqOGSOk1fxiN3u94bYkBW/wigj0Uw2Wt3vvRj9mtYdgwEjw=="
+      },
+      "verifiable.core": {
+        "type": "Project",
+        "dependencies": {
+          "SimpleBase": "[5.6.0, )",
+          "Verifiable.Jwt": "[0.0.0, )"
+        }
+      },
+      "verifiable.jwt": {
+        "type": "Project"
       },
       "verifiable.tpm": {
         "type": "Project",
@@ -48,6 +364,12 @@
         "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "87DBN+4ANSFO8TDRmFjjTBl6PL7tmrfofmxki4LUnE34gOdyQiBfJK/X1QSu0UfCGUtpoBVv/tD985s4FDpKiA=="
+      },
+      "SimpleBase": {
+        "type": "CentralTransitive",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
       }
     }
   }

--- a/test/Verifiable.Benchmarks/packages.lock.json
+++ b/test/Verifiable.Benchmarks/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "SIL.ReleaseTasks": {
         "type": "Direct",

--- a/test/Verifiable.Tests/ResultEqualityTests.cs
+++ b/test/Verifiable.Tests/ResultEqualityTests.cs
@@ -1,0 +1,215 @@
+﻿using Verifiable.Core;
+
+namespace Verifiable.Tests;
+
+/// <summary>
+/// Tests for <see cref="Result{TValue, TError}"/> <see cref="IEquatable{T}"/> implementation.
+/// </summary>
+[TestClass]
+public sealed class ResultEqualityTests
+{
+    private static Result<string, string> SuccessResult1 { get; } = Result.Success<string, string>("value1");
+    private static Result<string, string> SuccessResult2 { get; } = Result.Success<string, string>("value2");
+    private static Result<string, string> FailureResult1 { get; } = Result.Failure<string, string>("error1");
+    private static Result<string, string> FailureResult2 { get; } = Result.Failure<string, string>("error2");
+
+    [TestMethod]
+    public void SuccessResultsWithSameValueAreEqual()
+    {
+        var result1 = Result.Success<string, string>("test");
+        var result2 = Result.Success<string, string>("test");
+
+        Assert.IsTrue(result1.Equals(result2));
+        Assert.IsTrue(result1 == result2);
+        Assert.IsFalse(result1 != result2);
+    }
+
+    [TestMethod]
+    public void SuccessResultsWithDifferentValuesAreNotEqual()
+    {
+        Assert.IsFalse(SuccessResult1.Equals(SuccessResult2));
+        Assert.IsFalse(SuccessResult1 == SuccessResult2);
+        Assert.IsTrue(SuccessResult1 != SuccessResult2);
+    }
+
+    [TestMethod]
+    public void FailureResultsWithSameErrorAreEqual()
+    {
+        var result1 = Result.Failure<string, string>("error");
+        var result2 = Result.Failure<string, string>("error");
+
+        Assert.IsTrue(result1.Equals(result2));
+        Assert.IsTrue(result1 == result2);
+        Assert.IsFalse(result1 != result2);
+    }
+
+    [TestMethod]
+    public void FailureResultsWithDifferentErrorsAreNotEqual()
+    {
+        Assert.IsFalse(FailureResult1.Equals(FailureResult2));
+        Assert.IsFalse(FailureResult1 == FailureResult2);
+        Assert.IsTrue(FailureResult1 != FailureResult2);
+    }
+
+    [TestMethod]
+    public void SuccessAndFailureResultsAreNotEqual()
+    {
+        Assert.IsFalse(SuccessResult1.Equals(FailureResult1));
+        Assert.IsFalse(SuccessResult1 == FailureResult1);
+        Assert.IsTrue(SuccessResult1 != FailureResult1);
+    }
+
+    [TestMethod]
+    public void EqualsWithObjectOfSameTypeSucceeds()
+    {
+        object resultAsObject = Result.Success<string, string>("value1");
+
+        Assert.IsTrue(SuccessResult1.Equals(resultAsObject));
+    }
+
+    [TestMethod]
+    public void EqualsWithDifferentTypeReturnsFalse()
+    {
+        object differentType = new object();
+
+        Assert.IsFalse(SuccessResult1.Equals(differentType));
+    }
+
+    [TestMethod]
+    public void EqualsWithNullReturnsFalse()
+    {
+        object? nullObject = null;
+
+        Assert.IsFalse(SuccessResult1.Equals(nullObject));
+    }
+
+    [TestMethod]
+    public void GetHashCodeIsSameForEqualResults()
+    {
+        var result1 = Result.Success<string, string>("test");
+        var result2 = Result.Success<string, string>("test");
+
+        Assert.AreEqual(result1.GetHashCode(), result2.GetHashCode());
+    }
+
+    [TestMethod]
+    public void GetHashCodeDiffersForDifferentResults()
+    {
+        var hash1 = SuccessResult1.GetHashCode();
+        var hash2 = SuccessResult2.GetHashCode();
+        var hash3 = FailureResult1.GetHashCode();
+
+        Assert.AreNotEqual(hash1, hash2);
+        Assert.AreNotEqual(hash1, hash3);
+    }
+
+    [TestMethod]
+    public void ImplicitConversionCreatesSuccessResult()
+    {
+        Result<string, string> result = "implicitValue";
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual("implicitValue", result.Value);
+    }
+
+    [TestMethod]
+    public void ResultWithIntValueTypeWorksCorrectly()
+    {
+        var success = Result.Success<int, string>(42);
+        var failure = Result.Failure<int, string>("error");
+
+        Assert.IsTrue(success.IsSuccess);
+        Assert.AreEqual(42, success.Value);
+        Assert.IsFalse(failure.IsSuccess);
+        Assert.AreEqual("error", failure.Error);
+    }
+
+    [TestMethod]
+    public void ResultWithComplexTypesWorksCorrectly()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var success = Result.Success<List<int>, Exception>(list);
+
+        Assert.IsTrue(success.IsSuccess);
+        Assert.AreSame(list, success.Value);
+    }
+
+    [TestMethod]
+    public void MatchExecutesCorrectBranchForSuccess()
+    {
+        var result = Result.Success<string, string>("value");
+
+        string output = result.Match(
+            v => $"Success: {v}",
+            e => $"Failure: {e}");
+
+        Assert.AreEqual("Success: value", output);
+    }
+
+    [TestMethod]
+    public void MatchExecutesCorrectBranchForFailure()
+    {
+        var result = Result.Failure<string, string>("error");
+
+        string output = result.Match(
+            v => $"Success: {v}",
+            e => $"Failure: {e}");
+
+        Assert.AreEqual("Failure: error", output);
+    }
+
+    [TestMethod]
+    public void MapTransformsSuccessValue()
+    {
+        var result = Result.Success<int, string>(5);
+
+        var mapped = result.Map(x => x * 2);
+
+        Assert.IsTrue(mapped.IsSuccess);
+        Assert.AreEqual(10, mapped.Value);
+    }
+
+    [TestMethod]
+    public void MapPreservesFailure()
+    {
+        var result = Result.Failure<int, string>("error");
+
+        var mapped = result.Map(x => x * 2);
+
+        Assert.IsFalse(mapped.IsSuccess);
+        Assert.AreEqual("error", mapped.Error);
+    }
+
+    [TestMethod]
+    public void BindChainsSuccessfulOperations()
+    {
+        var result = Result.Success<int, string>(5);
+
+        var bound = result.Bind(x => Result.Success<int, string>(x * 2));
+
+        Assert.IsTrue(bound.IsSuccess);
+        Assert.AreEqual(10, bound.Value);
+    }
+
+    [TestMethod]
+    public void BindShortCircuitsOnFailure()
+    {
+        var result = Result.Failure<int, string>("initial error");
+
+        var bound = result.Bind(x => Result.Success<int, string>(x * 2));
+
+        Assert.IsFalse(bound.IsSuccess);
+        Assert.AreEqual("initial error", bound.Error);
+    }
+
+    [TestMethod]
+    public void BindPropagatesFailureFromChainedOperation()
+    {
+        var result = Result.Success<int, string>(5);
+
+        var bound = result.Bind(x => Result.Failure<int, string>("chained error"));
+
+        Assert.IsFalse(bound.IsSuccess);
+        Assert.AreEqual("chained error", bound.Error);
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/CommandLineIntegrationTests.cs
+++ b/test/Verifiable.Tests/ToolTests/CommandLineIntegrationTests.cs
@@ -1,0 +1,255 @@
+﻿namespace Verifiable.Tests.ToolTests;
+
+/// <summary>
+/// Integration tests that execute the actual command-line tool as a process.
+/// These tests verify end-to-end behavior including process startup, argument handling, and exit codes.
+/// </summary>
+[TestClass]
+public class CommandLineIntegrationTests
+{
+    /// <summary>
+    /// The MSTest context for the current test run.
+    /// </summary>
+    public TestContext TestContext { get; set; } = null!;
+
+
+    [TestMethod]
+    public async Task CliDidCreateReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did create 123 testParam", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidCreateWithExtraParamReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did create 456 myParam --extraParam extra", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidRevokeReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did revoke 789", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidListReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did list", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidViewReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did view 42", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliHelpReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "--help", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.Contains("did", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("info", result.Stdout, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidHelpReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did --help", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.Contains("create", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("revoke", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("list", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("view", result.Stdout, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    [TestMethod]
+    public async Task CliVersionReturnsSuccessExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "--version", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+    }
+
+
+    [TestMethod]
+    public async Task CliInvalidCommandReturnsNonZeroExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "unknowncommand", TestContext.CancellationToken);
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stderr.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidCreateMissingArgsReturnsNonZeroExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did create", TestContext.CancellationToken);
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stderr.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidCreateInvalidIdReturnsNonZeroExitCode()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did create notAnInt param", TestContext.CancellationToken);
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stderr.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidCreateUnicodeParameterSucceeds()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        string unicodeParam = "Wano_国_Gateway";
+        var result = await VerifiableCliTestHelpers.RunCliAsync(executablePath, ["did", "create", "1500000000", unicodeParam], TestContext.CancellationToken);
+
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsGreaterThan(0, result.Stdout.Length);
+    }
+
+
+    [TestMethod]
+    public async Task CliDidCreateBoundaryValuesSucceed()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var maxResult = await VerifiableCliTestHelpers.RunCliAsync(executablePath, $"did create {int.MaxValue} param", TestContext.CancellationToken);
+        var minResult = await VerifiableCliTestHelpers.RunCliAsync(executablePath, $"did create {int.MinValue} param", TestContext.CancellationToken);
+        var zeroResult = await VerifiableCliTestHelpers.RunCliAsync(executablePath, "did create 0 param", TestContext.CancellationToken);
+
+        Assert.AreEqual(0, maxResult.ExitCode);
+        Assert.AreEqual(0, minResult.ExitCode);
+        Assert.AreEqual(0, zeroResult.ExitCode);
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/CommandParsingPropertyTests.cs
+++ b/test/Verifiable.Tests/ToolTests/CommandParsingPropertyTests.cs
@@ -1,0 +1,149 @@
+﻿using System.CommandLine;
+using CsCheck;
+
+namespace Verifiable.Tests.ToolTests;
+
+/// <summary>
+/// Property-based tests for command-line parsing using CsCheck.
+/// </summary>
+[TestClass]
+public class CommandParsingPropertyTests
+{
+    [TestMethod]
+    public void ParseDidCreateAnyValidIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out var createIdArg, out _, out _);
+            ParseResult result = rootCommand.Parse($"did create {id} param");
+
+            Assert.IsEmpty(result.Errors);
+            Assert.AreEqual(id, result.GetValue(createIdArg));
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateAnyAlphanumericParamSucceeds()
+    {
+        Gen.String[1, 100].Sample(param =>
+        {
+            //Filter characters that affect System.CommandLine parsing.
+            //These are not bugs - they are intentional parser features (e.g. @ for response files).
+            //Business logic is tested with arbitrary inputs in McpServerPropertyTests.
+            if(VerifiableCliTestHelpers.IsUnsuitableForCliArgument(param))
+            {
+                return;
+            }
+
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out var createParamArg, out _);
+            ParseResult result = rootCommand.Parse($"did create 1 {param}");
+
+            Assert.IsEmpty(result.Errors);
+            Assert.AreEqual(param, result.GetValue(createParamArg));
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateAnyParamWithQuotesSucceeds()
+    {
+        Gen.String[1, 100].Sample(param =>
+        {
+            //Filter characters that affect System.CommandLine parsing.
+            //These are not bugs - they are intentional parser features (e.g. @ for response files).
+            //Business logic is tested with arbitrary inputs in McpServerPropertyTests.
+            if(VerifiableCliTestHelpers.ContainsCliSpecialCharacters(param))
+            {
+                return;
+            }
+
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out var createParamArg, out _);
+            ParseResult result = rootCommand.Parse(["did", "create", "1", param]);
+
+            Assert.IsEmpty(result.Errors);
+            Assert.AreEqual(param, result.GetValue(createParamArg));
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidRevokeAnyValidIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out _, out _);
+            ParseResult result = rootCommand.Parse($"did revoke {id}");
+
+            Assert.IsEmpty(result.Errors);
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidViewAnyValidIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out _, out _);
+            ParseResult result = rootCommand.Parse($"did view {id}");
+
+            Assert.IsEmpty(result.Errors);
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateExtraParamAnyStringSucceeds()
+    {
+        Gen.String[0, 50].Sample(extra =>
+        {
+            //Filter characters that affect System.CommandLine parsing.
+            //These are not bugs - they are intentional parser features (e.g. @ for response files).
+            //Business logic is tested with arbitrary inputs in McpServerPropertyTests.
+            if(VerifiableCliTestHelpers.IsUnsuitableForCliOptionValue(extra))
+            {
+                return;
+            }
+
+            var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out _, out var extraParamOpt);
+            ParseResult result = rootCommand.Parse(["did", "create", "1", "param", "--extraParam", extra]);
+
+            Assert.IsEmpty(result.Errors);
+            Assert.AreEqual(extra, result.GetValue(extraParamOpt));
+        });
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateNonIntegerIdAlwaysFails()
+    {
+        Gen.String[1, 20].Where(s => !int.TryParse(s, out _) && !string.IsNullOrWhiteSpace(s))
+            .Sample(invalidId =>
+            {
+                var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out _, out _);
+                ParseResult result = rootCommand.Parse($"did create {invalidId} param");
+
+                Assert.IsNotEmpty(result.Errors);
+            });
+    }
+
+
+    [TestMethod]
+    public void ParseRandomUnknownCommandAlwaysFails()
+    {
+        var knownCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "did", "info", "--help", "-h", "--version"
+        };
+
+        Gen.String[1, 20].Where(s => !knownCommands.Contains(s) && !string.IsNullOrWhiteSpace(s))
+            .Sample(unknownCommand =>
+            {
+                var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(out _, out _, out _);
+                ParseResult result = rootCommand.Parse(unknownCommand);
+
+                Assert.IsNotEmpty(result.Errors);
+            });
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/CommandParsingTests.cs
+++ b/test/Verifiable.Tests/ToolTests/CommandParsingTests.cs
@@ -1,0 +1,470 @@
+﻿using System.CommandLine;
+
+namespace Verifiable.Tests.ToolTests;
+
+
+/// <summary>
+/// Tests for command-line parsing behavior and command invocation.
+/// </summary>
+[TestClass]
+public class CommandParsingTests
+{
+    [TestMethod]
+    public void ParseDidCreateValidArgumentsNoErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out var extraParamOpt,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create 123 myParam");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(123, result.GetValue(createIdArg));
+        Assert.AreEqual("myParam", result.GetValue(createParamArg));
+        Assert.IsNull(result.GetValue(extraParamOpt));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateWithExtraParamParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out var extraParamOpt,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create 456 testParam --extraParam someExtra");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(456, result.GetValue(createIdArg));
+        Assert.AreEqual("testParam", result.GetValue(createParamArg));
+        Assert.AreEqual("someExtra", result.GetValue(extraParamOpt));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateWithShortExtraParamParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out var extraParamOpt,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create 789 param -e shortForm");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual("shortForm", result.GetValue(extraParamOpt));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateUsingAliasParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did new 100 aliasParam");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(100, result.GetValue(createIdArg));
+        Assert.AreEqual("aliasParam", result.GetValue(createParamArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidRevokeValidIdNoErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out var revokeIdArg, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did revoke 999");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(999, result.GetValue(revokeIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidListNoArgumentsNoErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did list");
+
+        Assert.IsEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseDidViewValidIdNoErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out var viewIdArg,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did view 42");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(42, result.GetValue(viewIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseInfoTpmNoArgumentsNoErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("info tpm");
+
+        Assert.IsEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateMissingRequiredArgumentsHasErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateInvalidIdTypeHasErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create notAnInt myParam");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseUnknownCommandHasErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("unknown command");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseUnknownOptionHasErrors()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create 1 param --unknownOption value");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseHelpOptionRecognizedWithoutError()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("--help");
+
+        Assert.IsEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseSubcommandHelpRecognizedWithoutError()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did --help");
+
+        Assert.IsEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseVersionOptionRecognizedWithoutError()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("--version");
+
+        Assert.IsEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void InvokeDidCreateReturnsSuccessExitCode()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out var extraParamOpt,
+            out _, out _, out var didCreateCommand, out _, out _, out _, out _);
+
+        int? capturedId = null;
+        string? capturedParam = null;
+        string? capturedExtra = null;
+
+        didCreateCommand.SetAction(parseResult =>
+        {
+            capturedId = parseResult.GetValue(createIdArg);
+            capturedParam = parseResult.GetValue(createParamArg);
+            capturedExtra = parseResult.GetValue(extraParamOpt);
+
+            return 0;
+        });
+
+        int exitCode = rootCommand.Parse("did create 123 testParam --extraParam extra").Invoke();
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(123, capturedId);
+        Assert.AreEqual("testParam", capturedParam);
+        Assert.AreEqual("extra", capturedExtra);
+    }
+
+
+    [TestMethod]
+    public void InvokeDidRevokeReturnsSuccessExitCode()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out var revokeIdArg, out _,
+            out _, out var didRevokeCommand, out _, out _, out _);
+
+        int? capturedId = null;
+
+        didRevokeCommand.SetAction(parseResult =>
+        {
+            capturedId = parseResult.GetValue(revokeIdArg);
+
+            return 0;
+        });
+
+        int exitCode = rootCommand.Parse("did revoke 456").Invoke();
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(456, capturedId);
+    }
+
+
+    [TestMethod]
+    public void InvokeDidListReturnsSuccessExitCode()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out var didListCommand, out _, out _);
+
+        bool commandExecuted = false;
+
+        didListCommand.SetAction(_ =>
+        {
+            commandExecuted = true;
+
+            return 0;
+        });
+
+        int exitCode = rootCommand.Parse("did list").Invoke();
+
+        Assert.AreEqual(0, exitCode);
+        Assert.IsTrue(commandExecuted);
+    }
+
+
+    [TestMethod]
+    public void InvokeDidViewReturnsSuccessExitCode()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out var viewIdArg,
+            out _, out _, out _, out var didViewCommand, out _);
+
+        int? capturedId = null;
+
+        didViewCommand.SetAction(parseResult =>
+        {
+            capturedId = parseResult.GetValue(viewIdArg);
+
+            return 0;
+        });
+
+        int exitCode = rootCommand.Parse("did view 789").Invoke();
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(789, capturedId);
+    }
+
+
+    [TestMethod]
+    public void InvokeInvalidArgumentsReturnsNonZeroExitCode()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        int exitCode = rootCommand.Parse("did create notANumber param").Invoke();
+
+        Assert.AreNotEqual(0, exitCode);
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateUnicodeParameterParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out var createParamArg, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        string unicodeParam = "Alabasta_航海_🏴‍☠️";
+        ParseResult result = rootCommand.Parse($"did create 1500000000 \"{unicodeParam}\"");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(1500000000, result.GetValue(createIdArg));
+        Assert.AreEqual(unicodeParam, result.GetValue(createParamArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateSpecialCharactersParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out var createParamArg, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        string specialParam = "test with spaces & special <chars>";
+        ParseResult result = rootCommand.Parse(["did", "create", "1", specialParam]);
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(specialParam, result.GetValue(createParamArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateEmptyStringParameterParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out var createParamArg, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse(["did", "create", "1", ""]);
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual("", result.GetValue(createParamArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateMaxIntIdParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out _, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse($"did create {int.MaxValue} param");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(int.MaxValue, result.GetValue(createIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateMinIntIdParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out _, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse($"did create {int.MinValue} param");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(int.MinValue, result.GetValue(createIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateZeroIdParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out _, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create 0 param");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(0, result.GetValue(createIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseDidCreateNegativeIdParsesCorrectly()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out var createIdArg, out _, out _,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("did create -42 param");
+
+        Assert.IsEmpty(result.Errors);
+        Assert.AreEqual(-42, result.GetValue(createIdArg));
+    }
+
+
+    [TestMethod]
+    public void ParseCommandsAreCaseSensitiveByDefault()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("DID CREATE 1 param");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+
+
+    [TestMethod]
+    public void ParseOptionsCaseVariations()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out var extraParamOpt,
+            out _, out _, out _, out _, out _, out _, out _);
+
+        ParseResult lowerResult = rootCommand.Parse("did create 1 param --extraparam value");
+        ParseResult correctResult = rootCommand.Parse("did create 1 param --extraParam value");
+
+        bool lowerHasErrorsOrNull = lowerResult.Errors.Count > 0 || lowerResult.GetValue(extraParamOpt) == null;
+        Assert.IsTrue(lowerHasErrorsOrNull);
+        Assert.AreEqual("value", correctResult.GetValue(extraParamOpt));
+    }
+
+
+    [TestMethod]
+    public void ParseMcpArgumentShouldNotBeHandledByMainCommands()
+    {
+        var rootCommand = VerifiableCliTestHelpers.BuildTestableRootCommand(
+            out _, out _, out _, out _, out _,
+            out _, out _, out _, out _, out _);
+
+        ParseResult result = rootCommand.Parse("-mcp");
+
+        Assert.IsNotEmpty(result.Errors);
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/McpServerPropertyTests.cs
+++ b/test/Verifiable.Tests/ToolTests/McpServerPropertyTests.cs
@@ -1,0 +1,211 @@
+﻿using CsCheck;
+using Verifiable.Core;
+
+namespace Verifiable.Tests.ToolTests;
+
+/// <summary>
+/// Property-based tests for VerifiableOperations and MCP tools using CsCheck.
+/// </summary>
+[TestClass]
+public class McpServerPropertyTests
+{
+    [TestMethod]
+    public void CreateDidAnyIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result = VerifiableOperations.CreateDid(id, "param", null);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+            Assert.Contains(id.ToString(), result.Value, StringComparison.Ordinal);
+        });
+    }
+
+
+    [TestMethod]
+    public void CreateDidAnyStringParamSucceeds()
+    {
+        Gen.String[0, 1000].Sample(param =>
+        {
+            var result = VerifiableOperations.CreateDid(1, param, null);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+        });
+    }
+
+
+    [TestMethod]
+    public void CreateDidAnyExtraParamSucceeds()
+    {
+        Gen.String[0, 500].Sample(extra =>
+        {
+            var result = VerifiableOperations.CreateDid(1, "param", extra);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+        });
+    }
+
+
+    [TestMethod]
+    public void CreateDidNullExtraParamSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result = VerifiableOperations.CreateDid(id, "param", null);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.DoesNotContain("Extra parameter:", result.Value!, StringComparison.Ordinal);
+        });
+    }
+
+
+    [TestMethod]
+    public void CreateDidWithExtraParamContainsExtraInOutput()
+    {
+        Gen.String[1, 100].Where(s => !string.IsNullOrWhiteSpace(s)).Sample(extra =>
+        {
+            var result = VerifiableOperations.CreateDid(1, "param", extra);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.Contains(extra, result.Value!, StringComparison.Ordinal);
+        });
+    }
+
+
+    [TestMethod]
+    public void RevokeDidAnyIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result = VerifiableOperations.RevokeDid(id);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+            Assert.Contains(id.ToString(), result.Value, StringComparison.Ordinal);
+        });
+    }
+
+
+    [TestMethod]
+    public void ViewDidAnyIntegerIdSucceeds()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result = VerifiableOperations.ViewDid(id);
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+            Assert.Contains(id.ToString(), result.Value, StringComparison.Ordinal);
+        });
+    }
+
+
+    [TestMethod]
+    public void ListDidsAlwaysSucceeds()
+    {
+        for(int i = 0; i < 100; i++)
+        {
+            var result = VerifiableOperations.ListDids();
+
+            Assert.IsTrue(result.IsSuccess);
+            Assert.IsNotNull(result.Value);
+        }
+    }
+
+
+    [TestMethod]
+    public void CheckTpmSupportMessageNeverThrows()
+    {
+        for(int i = 0; i < 100; i++)
+        {
+            string result = VerifiableOperations.CheckTpmSupportMessage();
+
+            Assert.IsNotNull(result);
+            Assert.IsGreaterThan(0, result.Length);
+        }
+    }
+
+
+    [TestMethod]
+    public void GetTpmInfoAsJsonNeverThrows()
+    {
+        for(int i = 0; i < 100; i++)
+        {
+            var result = VerifiableOperations.GetTpmInfoAsJson();
+
+            Assert.IsTrue(result.IsSuccess || !string.IsNullOrEmpty(result.Error));
+        }
+    }
+
+
+    [TestMethod]
+    public void CreateDidUnicodeStringsSucceed()
+    {
+        var unicodeStrings = new[]
+        {
+            "NewWorld_Protocol",
+            "RedLine_Crossing",
+            "Alabasta_Region",
+            "Dressrosa_Network",
+            "Sabaody_Cluster",
+            "Wano_国_Gateway",
+            "GrandLine_航路",
+            "Skypiea_雲_Node",
+        };
+
+        foreach(var unicode in unicodeStrings)
+        {
+            var result = VerifiableOperations.CreateDid(1, unicode, null);
+
+            Assert.IsTrue(result.IsSuccess, $"Failed for: {unicode}");
+            Assert.IsNotNull(result.Value);
+        }
+    }
+
+
+    [TestMethod]
+    public void CreateDidVeryLongStringsSucceed()
+    {
+        var lengths = new[] { 1000, 5000, 10000, 50000 };
+
+        foreach(var length in lengths)
+        {
+            string longParam = new('x', length);
+            var result = VerifiableOperations.CreateDid(1, longParam, null);
+
+            Assert.IsTrue(result.IsSuccess, $"Failed for length: {length}");
+            Assert.IsNotNull(result.Value);
+        }
+    }
+
+
+    [TestMethod]
+    public void OperationResultEqualityIsConsistent()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result1 = VerifiableOperations.CreateDid(id, "param", null);
+            var result2 = VerifiableOperations.CreateDid(id, "param", null);
+
+            Assert.AreEqual(result1.IsSuccess, result2.IsSuccess);
+        });
+    }
+
+    [TestMethod]
+    public void OperationResultSuccessAndFailureAreMutuallyExclusive()
+    {
+        Gen.Int.Sample(id =>
+        {
+            var result = VerifiableOperations.CreateDid(id, "param", null);
+
+            bool hasValue = result.Value is not null;
+            bool hasError = result.Error is not null;
+
+            Assert.AreEqual(result.IsSuccess, hasValue, "IsSuccess should match presence of Value.");
+            Assert.AreNotEqual(result.IsSuccess, hasError, "IsSuccess and HasError should be mutually exclusive.");
+        });
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/McpServerTests.cs
+++ b/test/Verifiable.Tests/ToolTests/McpServerTests.cs
@@ -1,0 +1,424 @@
+﻿using ModelContextProtocol.Client;
+using System.Text.Json;
+
+namespace Verifiable.Tests.ToolTests;
+
+/// <summary>
+/// Tests for the shared operations and MCP server functionality.
+/// </summary>
+[TestClass]
+public class McpServerTests
+{
+    /// <summary>
+    /// Gets or sets the context information for the current test run, including test metadata and utilities for logging
+    /// and result tracking.
+    /// </summary>
+    /// <remarks>Use this property to access details about the executing test, such as its name, outcome, and
+    /// associated data. The property is typically set by the test framework and should not be assigned manually in user
+    /// code.</remarks>
+    public TestContext TestContext { get; set; } = null!;
+
+
+    [TestMethod]
+    public void CheckTpmSupportMessageReturnsValidResponse()
+    {
+        string result = VerifiableOperations.CheckTpmSupportMessage();
+
+        Assert.IsNotNull(result);
+        Assert.IsGreaterThan(0, result.Length);
+        Assert.Contains("supported", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("platform", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    [TestMethod]
+    public void CreateDidValidParametersReturnsSuccess()
+    {
+        int id = 123;
+        string param = "testParam";
+        string? extraParam = "extraValue";
+
+        var result = VerifiableOperations.CreateDid(id, param, extraParam);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+        Assert.Contains("123", result.Value, StringComparison.Ordinal);
+        Assert.Contains("testParam", result.Value, StringComparison.Ordinal);
+        Assert.Contains("extraValue", result.Value, StringComparison.Ordinal);
+    }
+
+
+    [TestMethod]
+    public void CreateDidWithoutExtraParamReturnsSuccess()
+    {
+        int id = 456;
+        string param = "myParam";
+
+        var result = VerifiableOperations.CreateDid(id, param, null);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+        Assert.Contains("456", result.Value, StringComparison.Ordinal);
+        Assert.Contains("myParam", result.Value, StringComparison.Ordinal);
+        Assert.DoesNotContain("Extra parameter:", result.Value, StringComparison.Ordinal);
+    }
+
+
+    [TestMethod]
+    public void RevokeDidValidIdReturnsSuccess()
+    {
+        int id = 789;
+
+        var result = VerifiableOperations.RevokeDid(id);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+        Assert.Contains("789", result.Value, StringComparison.Ordinal);
+        Assert.Contains("Revoked", result.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    [TestMethod]
+    public void ListDidsReturnsSuccess()
+    {
+        var result = VerifiableOperations.ListDids();
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+    }
+
+
+    [TestMethod]
+    public void ViewDidValidIdReturnsSuccess()
+    {
+        int id = 42;
+
+        var result = VerifiableOperations.ViewDid(id);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+        Assert.Contains("42", result.Value, StringComparison.Ordinal);
+    }
+
+
+    [TestMethod]
+    public void GetTpmInfoAsJsonReturnsValidJsonOrError()
+    {
+        var result = VerifiableOperations.GetTpmInfoAsJson();
+
+        if(result.IsSuccess)
+        {
+            using var doc = JsonDocument.Parse(result.Value!);
+            Assert.AreEqual(JsonValueKind.Object, doc.RootElement.ValueKind);
+        }
+        else
+        {
+            Assert.IsNotNull(result.Error);
+            bool hasExpectedError = result.Error.Contains("not supported", StringComparison.Ordinal) ||
+                                    result.Error.Contains("Error", StringComparison.Ordinal);
+            Assert.IsTrue(hasExpectedError, "Error message should indicate not supported or error.");
+        }
+    }
+
+
+    [TestMethod]
+    public async Task SaveTpmInfoToFileAsyncReturnsExpectedResult()
+    {
+        string testFilePath = Path.Combine(Path.GetTempPath(), $"test_tpm_{Guid.NewGuid()}.json");
+
+        try
+        {
+            var result = await VerifiableOperations.SaveTpmInfoToFileAsync(testFilePath);
+
+            if(result.IsSuccess)
+            {
+                Assert.IsNotNull(result.Value);
+                Assert.IsTrue(File.Exists(testFilePath), "File should exist when save succeeds.");
+            }
+            else
+            {
+                Assert.IsNotNull(result.Error);
+                bool hasExpectedError = result.Error.Contains("not supported", StringComparison.Ordinal) ||
+                                        result.Error.Contains("Error", StringComparison.Ordinal);
+                Assert.IsTrue(hasExpectedError, "Error message should be clear.");
+            }
+        }
+        finally
+        {
+            if(File.Exists(testFilePath))
+            {
+                File.Delete(testFilePath);
+            }
+        }
+    }
+
+
+    [TestMethod]
+    public async Task SaveTpmInfoToFileAsyncNullPathUsesDefaultFileName()
+    {
+        var result = await VerifiableOperations.SaveTpmInfoToFileAsync(null);
+
+        if(result.IsSuccess)
+        {
+            Assert.IsNotNull(result.Value);
+            Assert.Contains("tpm_data.json", result.Value, StringComparison.Ordinal);
+        }
+    }
+
+
+    [TestMethod]
+    public void CreateDidBoundaryValuesHandlesCorrectly()
+    {
+        var maxResult = VerifiableOperations.CreateDid(int.MaxValue, "param", null);
+        Assert.IsTrue(maxResult.IsSuccess);
+        Assert.Contains(int.MaxValue.ToString(), maxResult.Value!, StringComparison.Ordinal);
+
+        var minResult = VerifiableOperations.CreateDid(int.MinValue, "param", null);
+        Assert.IsTrue(minResult.IsSuccess);
+        Assert.Contains(int.MinValue.ToString(), minResult.Value!, StringComparison.Ordinal);
+
+        var zeroResult = VerifiableOperations.CreateDid(0, "param", null);
+        Assert.IsTrue(zeroResult.IsSuccess);
+        Assert.Contains("0", zeroResult.Value!, StringComparison.Ordinal);
+    }
+
+
+    [TestMethod]
+    public void CreateDidUnicodeParametersHandlesCorrectly()
+    {
+        string unicodeParam = "日本語_émojis_🔐🔑_中文";
+        string unicodeExtra = "مرحبا_שלום_Привет";
+
+        var result = VerifiableOperations.CreateDid(1, unicodeParam, unicodeExtra);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.Contains(unicodeParam, result.Value!, StringComparison.Ordinal);
+        Assert.Contains(unicodeExtra, result.Value!, StringComparison.Ordinal);
+    }
+
+
+    [TestMethod]
+    public void CreateDidEmptyStringParameterHandlesCorrectly()
+    {
+        var result = VerifiableOperations.CreateDid(1, "", "");
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+    }
+
+
+    [TestMethod]
+    public void CreateDidVeryLongParameterHandlesCorrectly()
+    {
+        string longParam = new string('x', 10000);
+
+        var result = VerifiableOperations.CreateDid(1, longParam, null);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Value);
+        Assert.Contains(longParam, result.Value, StringComparison.Ordinal);
+    }
+
+
+    /// <summary>
+    /// Tests that the MCP server process starts correctly with -mcp argument via stdio.
+    /// </summary>
+    [TestMethod]
+    public async Task McpServerStartsSuccessfullyViaStdio()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        using var process = VerifiableCliTestHelpers.CreateMcpServerProcess(executablePath);
+
+        try
+        {
+            process.Start();
+            await Task.Delay(500, TestContext.CancellationToken);
+
+            Assert.IsFalse(process.HasExited, "MCP server should still be running after startup.");
+
+            var initializeRequest = new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "initialize",
+                @params = new
+                {
+                    protocolVersion = "2025-11-25",
+                    capabilities = new { },
+                    clientInfo = new
+                    {
+                        name = "test-client",
+                        version = "1.0.0"
+                    }
+                }
+            };
+
+            string requestJson = JsonSerializer.Serialize(initializeRequest);
+            await process.StandardInput.WriteLineAsync(requestJson.AsMemory(), TestContext.CancellationToken);
+            await process.StandardInput.FlushAsync(TestContext.CancellationToken);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            string? response = await VerifiableCliTestHelpers.ReadLineWithTimeoutAsync(process.StandardOutput, cts.Token);
+
+            Assert.IsNotNull(response, "Should receive a response from MCP server.");
+
+            using var responseDoc = JsonDocument.Parse(response);
+            var root = responseDoc.RootElement;
+
+            Assert.IsTrue(root.TryGetProperty("jsonrpc", out var jsonrpc));
+            Assert.AreEqual("2.0", jsonrpc.GetString());
+
+            Assert.IsTrue(root.TryGetProperty("id", out var id));
+            Assert.AreEqual(1, id.GetInt32());
+
+            Assert.IsTrue(root.TryGetProperty("result", out _), "Should have result property.");
+        }
+        finally
+        {
+            await VerifiableCliTestHelpers.EnsureProcessTerminatedAsync(process, TestContext.CancellationToken);
+        }
+    }
+
+
+    /// <summary>
+    /// Tests MCP server lists available tools via stdio.
+    /// </summary>
+    [TestMethod]
+    public async Task McpServerListsToolsViaStdio()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found.");
+
+            return;
+        }
+
+        using var process = VerifiableCliTestHelpers.CreateMcpServerProcess(executablePath);
+
+        try
+        {
+            process.Start();
+
+            var initRequest = JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "initialize",
+                @params = new
+                {
+                    protocolVersion = "2025-11-25",
+                    capabilities = new { },
+                    clientInfo = new { name = "test", version = "1.0" }
+                }
+            });
+
+            await process.StandardInput.WriteLineAsync(initRequest.AsMemory(), TestContext.CancellationToken);
+            await process.StandardInput.FlushAsync(TestContext.CancellationToken);
+
+            using var cts1 = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+            cts1.CancelAfter(TimeSpan.FromSeconds(5));
+            await VerifiableCliTestHelpers.ReadLineWithTimeoutAsync(process.StandardOutput, cts1.Token);
+
+            var initializedNotification = JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                method = "notifications/initialized"
+            });
+
+            await process.StandardInput.WriteLineAsync(initializedNotification.AsMemory(), TestContext.CancellationToken);
+            await process.StandardInput.FlushAsync(TestContext.CancellationToken);
+
+            var toolsRequest = JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                id = 2,
+                method = "tools/list"
+            });
+
+            await process.StandardInput.WriteLineAsync(toolsRequest.AsMemory(), TestContext.CancellationToken);
+            await process.StandardInput.FlushAsync(TestContext.CancellationToken);
+
+            using var cts2 = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+            cts2.CancelAfter(TimeSpan.FromSeconds(5));
+            string? response = await VerifiableCliTestHelpers.ReadLineWithTimeoutAsync(process.StandardOutput, cts2.Token);
+
+            Assert.IsNotNull(response);
+
+            using var responseDoc = JsonDocument.Parse(response);
+            var root = responseDoc.RootElement;
+
+            Assert.IsTrue(root.TryGetProperty("result", out var result));
+            Assert.IsTrue(result.TryGetProperty("tools", out var tools));
+            Assert.IsGreaterThan(0, tools.GetArrayLength());
+
+            var toolNames = new List<string>();
+            foreach(var tool in tools.EnumerateArray())
+            {
+                if(tool.TryGetProperty("name", out var name))
+                {
+                    toolNames.Add(name.GetString() ?? "");
+                }
+            }
+
+            Assert.IsGreaterThan(0, toolNames.Count, "Should have at least one tool registered.");
+
+            Assert.Contains(McpToolNames.GetTpmInfo, toolNames);
+            Assert.Contains(McpToolNames.CheckTpmSupport, toolNames);
+            Assert.Contains(McpToolNames.CreateDid, toolNames);
+            Assert.Contains(McpToolNames.ListDids, toolNames);
+        }
+        finally
+        {
+            await VerifiableCliTestHelpers.EnsureProcessTerminatedAsync(process, TestContext.CancellationToken);
+        }
+    }
+
+
+    /// <summary>
+    /// Tests connecting to the MCP server using the official client SDK via stdio.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("McpClient")]
+    public async Task McpClientConnectsToServerViaStdio()
+    {
+        string? executablePath = VerifiableCliTestHelpers.GetExecutablePath();
+        if(executablePath is null)
+        {
+            Assert.Inconclusive("Executable not found. Build the project first.");
+
+            return;
+        }
+
+        var clientTransport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Name = "Verifiable MCP Server",
+            Command = executablePath,
+            Arguments = ["-mcp"]
+        });
+
+        await using var client = await McpClient.CreateAsync(clientTransport, cancellationToken: TestContext.CancellationToken);
+
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.CancellationToken);
+        var toolNames = tools.Select(t => t.Name).ToList();
+
+        Assert.IsGreaterThan(0, tools.Count);
+        Assert.Contains(McpToolNames.CheckTpmSupport, toolNames);
+        Assert.Contains(McpToolNames.ListDids, toolNames);
+
+        var result = await client.CallToolAsync(
+            McpToolNames.ListDids,
+            new Dictionary<string, object?>(),
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsNotNull(result);
+    }
+}

--- a/test/Verifiable.Tests/ToolTests/VerifiableCliTestHelpers.cs
+++ b/test/Verifiable.Tests/ToolTests/VerifiableCliTestHelpers.cs
@@ -1,0 +1,284 @@
+﻿using System.CommandLine;
+using System.Diagnostics;
+
+namespace Verifiable.Tests.ToolTests;
+
+/// <summary>
+/// Result of running a CLI command.
+/// </summary>
+/// <param name="ExitCode">The process exit code. Zero indicates success.</param>
+/// <param name="Stdout">The standard output captured from the process.</param>
+/// <param name="Stderr">The standard error captured from the process.</param>
+public readonly record struct CliResult(int ExitCode, string Stdout, string Stderr);
+
+/// <summary>
+/// Shared test infrastructure and helper methods for test classes.
+/// </summary>
+public static class VerifiableCliTestHelpers
+{
+    /// <summary>
+    /// Characters that have special meaning in System.CommandLine parsing.
+    /// These are intentional parser features (e.g. @ for response files, &lt; &gt; for redirection).
+    /// </summary>
+    private static char[] CliSpecialCharacters { get; } =
+    [
+        ' ', '"', '\'', '`', '|', '$', ';', '&', '<', '>', '\\', '@'
+    ];
+
+
+    /// <summary>
+    /// Checks if a string contains characters that have special meaning in CLI parsing.
+    /// </summary>
+    public static bool ContainsCliSpecialCharacters(string value)
+    {
+        return value.AsSpan().IndexOfAny(CliSpecialCharacters) >= 0;
+    }
+
+
+    /// <summary>
+    /// Checks if a string is unsuitable for unquoted CLI argument use.
+    /// </summary>
+    public static bool IsUnsuitableForCliArgument(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) || ContainsCliSpecialCharacters(value);
+    }
+
+
+    /// <summary>
+    /// Checks if a string is unsuitable for CLI option value use.
+    /// </summary>
+    public static bool IsUnsuitableForCliOptionValue(string value)
+    {
+        return ContainsCliSpecialCharacters(value) || value.StartsWith('-');
+    }
+
+
+    /// <summary>
+    /// Builds a testable root command that mirrors the structure in Program.cs.
+    /// </summary>
+    public static RootCommand BuildTestableRootCommand(
+        out Argument<int> createIdArgument,
+        out Argument<string> createParamArgument,
+        out Option<string?> extraParamOption,
+        out Argument<int> revokeIdArgument,
+        out Argument<int> viewIdArgument,
+        out Command didCreateCommand,
+        out Command didRevokeCommand,
+        out Command didListCommand,
+        out Command didViewCommand,
+        out Command infoTpmCommand)
+    {
+        RootCommand rootCommand = new("A command line tool for security elements, DIDs and VCs");
+
+        Command didCommand = new("did", "Create, revoke, list or view DIDs.");
+        rootCommand.Subcommands.Add(didCommand);
+
+        createIdArgument = new("id") { Description = "Identifier for the new DID document." };
+        createParamArgument = new("param") { Description = "New DID document parameter." };
+        extraParamOption = new("--extraParam", "-e") { Description = "Some extra parameter." };
+
+        didCreateCommand = new("create", "Create a new DID document.")
+        {
+            createIdArgument,
+            createParamArgument,
+            extraParamOption
+        };
+        didCreateCommand.Aliases.Add("new");
+        didCommand.Subcommands.Add(didCreateCommand);
+
+        revokeIdArgument = new("id") { Description = "Identifier to revoke a DID document." };
+        didRevokeCommand = new("revoke", "Revoke a DID document.")
+        {
+            revokeIdArgument
+        };
+        didCommand.Subcommands.Add(didRevokeCommand);
+
+        didListCommand = new("list", "List all DID documents.");
+        didCommand.Subcommands.Add(didListCommand);
+
+        viewIdArgument = new("id") { Description = "DID identifier for a document to view." };
+        didViewCommand = new("view", "View DID document.")
+        {
+            viewIdArgument
+        };
+        didCommand.Subcommands.Add(didViewCommand);
+
+        Command infoCommand = new("info", "Print selected platform information (only tpm currently).");
+        rootCommand.Subcommands.Add(infoCommand);
+
+        infoTpmCommand = new("tpm", "Print trusted platform module (TPM) information.");
+        infoCommand.Subcommands.Add(infoTpmCommand);
+
+        return rootCommand;
+    }
+
+
+    /// <summary>
+    /// Simplified overload for tests that only need a subset of arguments.
+    /// </summary>
+    public static RootCommand BuildTestableRootCommand(
+        out Argument<int> createIdArgument,
+        out Argument<string> createParamArgument,
+        out Option<string?> extraParamOption)
+    {
+        return BuildTestableRootCommand(
+            out createIdArgument,
+            out createParamArgument,
+            out extraParamOption,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _);
+    }
+
+
+    /// <summary>
+    /// Gets the path to the built executable, or null if not found.
+    /// </summary>
+    public static string? GetExecutablePath()
+    {
+        string basePath = AppContext.BaseDirectory;
+        string projectRoot = Path.GetFullPath(Path.Combine(basePath, "../../../../.."));
+
+        string[] configurations = ["Debug", "Release"];
+        string[] projectPaths = ["src/Verifiable", "Verifiable"];
+        string extension = OperatingSystem.IsWindows() ? ".exe" : "";
+
+        foreach(var projectPath in projectPaths)
+        {
+            foreach(var config in configurations)
+            {
+                string path = Path.Combine(projectRoot, projectPath, "bin", config, "net10.0", $"verifiable{extension}");
+                if(File.Exists(path))
+                {
+                    return path;
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+    /// <summary>
+    /// Creates a process configured for MCP server testing with stdio redirection.
+    /// </summary>
+    public static Process CreateMcpServerProcess(string executablePath)
+    {
+        return new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                Arguments = "-mcp",
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+    }
+
+
+    /// <summary>
+    /// Ensures an MCP server process is terminated.
+    /// </summary>
+    public static async Task EnsureProcessTerminatedAsync(Process process, CancellationToken cancellationToken = default)
+    {
+        if(!process.HasExited)
+        {
+            process.Kill();
+            await process.WaitForExitAsync(cancellationToken);
+        }
+    }
+
+
+    /// <summary>
+    /// Reads a line from a stream reader with timeout support.
+    /// </summary>
+    public static async Task<string?> ReadLineWithTimeoutAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await reader.ReadLineAsync(cancellationToken);
+        }
+        catch(OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Runs the CLI executable with the specified arguments and returns the result.
+    /// </summary>
+    public static async Task<CliResult> RunCliAsync(
+        string executablePath,
+        string arguments,
+        CancellationToken cancellationToken = default)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+
+        string stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        string stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new CliResult(process.ExitCode, stdout, stderr);
+    }
+
+
+    /// <summary>
+    /// Runs the CLI executable with the specified argument array and returns the result.
+    /// </summary>
+    public static async Task<CliResult> RunCliAsync(
+        string executablePath,
+        string[] arguments,
+        CancellationToken cancellationToken = default)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+
+        foreach(var arg in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        process.Start();
+
+        string stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        string stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new CliResult(process.ExitCode, stdout, stderr);
+    }
+}

--- a/test/Verifiable.Tests/Verifiable.Tests.csproj
+++ b/test/Verifiable.Tests/Verifiable.Tests.csproj
@@ -24,6 +24,9 @@
     <PackageReference Include="CsCheck" />
     <PackageReference Include="LiquidTestReports.Markdown" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,5 +37,6 @@
     <ProjectReference Include="..\..\src\Verifiable.NSec\Verifiable.NSec.csproj" />
     <ProjectReference Include="..\..\src\Verifiable.Sidetree\Verifiable.Sidetree.csproj" />
     <ProjectReference Include="..\..\src\Verifiable.Tpm\Verifiable.Tpm.csproj" />
+    <ProjectReference Include="..\..\src\Verifiable\Verifiable.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Verifiable.Tests/packages.lock.json
+++ b/test/Verifiable.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "CsCheck": {
         "type": "Direct",
-        "requested": "[4.4.1, )",
-        "resolved": "4.4.1",
-        "contentHash": "9AnhoINTGlGRkJ2GOHpV8E4UiIiv46rTX3ssp0H2x29khh69Lli8q0c+LAxK9gVpckuXBo0Wq+NG2QQ44F8EHg=="
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "yr4KUycAY+6Hx8r7BYyLjymHiFFOVoOTokS54f9y0tRrKdbQUEc+i1ojwdr/gjme8ZeZnRGP68XgfUFZfYO/MQ=="
       },
       "dotNetRdf": {
         "type": "Direct",
@@ -38,11 +38,41 @@
           "Microsoft.TestPlatform.ObjectModel": "16.9.1"
         }
       },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "0jjfjQSOFZlHhwOoIQw0WyzxtkDMYdnPY3iFrOLasxYq/5J4FDt1HWT8TktBclOVjFY1FOOkoOc99X7AhbqSIw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.1",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Json": "10.0.1",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Diagnostics": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.1",
+          "Microsoft.Extensions.Logging.Console": "10.0.1",
+          "Microsoft.Extensions.Logging.Debug": "10.0.1",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.1",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
-        "requested": "[4.1.4, )",
-        "resolved": "4.1.4",
-        "contentHash": "ZC3r/TTZ9BELNFYstmL8GRzHK+KuMxaCzF5Rd3wsvKFGNgiPoOdhzPCw5Vt9YKgNbcdqYT6eid96NxMUJfVteg=="
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
       },
       "Microsoft.Testing.Extensions.AzureDevOpsReport": {
         "type": "Direct",
@@ -122,6 +152,16 @@
           "Microsoft.Testing.Platform": "2.0.2"
         }
       },
+      "ModelContextProtocol": {
+        "type": "Direct",
+        "requested": "[0.5.0-preview.1, )",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "QJpuNEnMZLJmvASbZ2nvMqENTZk3HYF83IihoHs3EJ5vTlz4sYjji9bXh2HP5UxpXIdHGn0iuHu0X2Tpq2zilw==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "ModelContextProtocol.Core": "0.5.0-preview.1"
+        }
+      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[4.0.2, )",
@@ -150,6 +190,12 @@
         "dependencies": {
           "Markdig.Signed": "0.37.0"
         }
+      },
+      "System.CommandLine": {
+        "type": "Direct",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "GLc43eDFq8KbpxIb7UhTwV0vC5CzB0NspJvfFbfhoW4O057xCJXuO18KLpVn9x3JykQn2mRske6+I6JXHwqmDg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Direct",
@@ -365,37 +411,265 @@
         "resolved": "2.0.0",
         "contentHash": "QcZrCETsBJqy/vQpFtJc+jSXQ0K5sucQ6NUFbTNVHD4vfZZOwjZ/3sBzczkC4DityhD3AVO/+K/+9ioLs1AgRA=="
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "PHeuDm2tC6wJPEQvleUr2kNQaIMNqSf3aEbzkIPlZyQ0+0SYI9SwXVLdGD1NPBI+xB+Vb2lxZKhrFlIf9kP9WA=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "9.0.9",
-        "contentHash": "w87wF/90/VI0ZQBhf4rbMEeyEy0vi2WKjFmACsNAKNaorY+ZlVz7ddyXkbADvaWouMKffNmR0yQOGcrvSSvKGg==",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.9",
-          "Microsoft.Extensions.Primitives": "9.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.9",
-        "contentHash": "p5RKAY9POvs3axwA/AQRuJeM8AHuE8h4qbP1NxQeGm0ep46aXz1oCLAp/oOYxX1GsjStgdhHrN3XXLLXr0+b3w==",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "9.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.1"
         }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Lp4CZIuTVXtlvkAnTq6QvMSW7+H62gX2cU2vdFxHQUxvrWTpi7LwYI3X+YAyIS0r12/p7gaosco7efIxL4yFNw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "s5cxcdtIig66YT3J+7iHflMuorznK8kXuwBBPHMp4KImx5ZGE3FRa1Nj9fI/xMwFV+KzUMjqZ2MhOedPH8LiBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "csD8Eps3HQ3yc0x6NhgTV+aIFKSs3qVlVCtFnMHz/JOjnv7eEj/qSXKXiK9LzBzB1qSfAVqFnB5iaX2nUmagIQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "N/6GiwiZFCBFZDk3vg1PhHW3zMqqu5WWpmeZAA9VTXv7Q8pr8NZR/EQsH0DjzqydDksJtY6EQBsu81d5okQOlA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "0zW3eYBJlRctmgqk5s0kFIi5o5y2g80mvGCD8bkYxREPQlKUnr0ndU/Sop+UDIhyWN0fIi4RW63vo7BKTi7ncA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "ULEJ0nkaW90JYJGkFujPcJtADXcJpXiSOLbokPcWJZ8iDbtDINifEYAUVqZVr81IDNTrRFul6O8RolOKOsgFPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Json": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "6.0.2",
         "contentHash": "HS5YsudCGSVoCVdsYJ5FAO9vx0z04qSAXgVzpDJSQ1/w/X9q8hrQVGU2p+Yfui+2KcXLL+Zjc0SX3yJWtBmYiw=="
       },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YaocqxscJLxLit0F5yq2XyB+9C7rSRfeTL7MJIl7XwaOoUO3i0EqfO2kmtjiRduYWw7yjcSINEApYZbzjau2gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "QMoMrkNpnQym5mpfdxfxpRDuqLpsOuztguFvzH9p+Ex+do+uLFoi7UkAsBO4e9/tNR3eMFraFf2fOAi2cp3jjA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "+b3DligYSZuoWltU5YdbMpIEUHNZPgPrzWfNiIuDkMdqOl93UxYB5KzS3lgpRfTXJhTNpo/CZ8w/sTkDTPDdxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "4bxzGXIzZnz0Bf7czQ72jGvpOqJsRW/44PS7YLFXTTnu6cNcPvmSREDvBoH0ZVP2hAbMfL4sUoCUn54k70jPWw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "49dFvGJjLSwGn76eHnP1gBvCJkL8HRYpCrG0DCvsP6wRpEQRLN2Fq8rTxbP+6jS7jmYKCnSVO5C65v4mT3rzeA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "qmoQkVZcbm4/gFpted3W3Y+1kTATZTcUhV3mRkbtpfBXlxWCHwh/2oMffVcCruaGOfJuEnyAsGyaSUouSdECOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "9ItMpMLFZFJFqCuHLLbR3LiA4ahA8dMtYuXpXl2YamSDWZhYS9BruPprkftY0tYi2bQ0slNrixdFm+4kpz1g5w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.4",
-        "contentHash": "K14wYgwOfKVELrUh5eBqlC8Wvo9vvhS3ZhIvcswV2uS/ubkTRPSQsN557EZiYUSSoZNxizG+alN4wjtdyLdcyw=="
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Zg8LLnfZs5o2RCHD/+9NfDtJ40swauemwCa7sI8gQoAye/UJHRZNpCtC7a5XE7l9Z7mdI8iMWnLZ6m7Q6S3jLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "38Q8sEHwQ/+wVO/mwQBa0fcdHbezFpusHE+vBw/dSr6Fq/kzZm3H/NQX511Jki/R3FHd64IY559gdlHZQtYeEA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "VqfTvbX9C6BA0VeIlpzPlljnNsXxiI5CdUHb9ksWERH94WQ6ft3oLGUAa4xKcDGu4xF+rIZ8wj7IOAd6/q7vGw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Zp9MM+jFCa7oktIug62V9eNygpkf+6kFVatF+UC/ODeUwIr5givYKy8fYSSI9sWdxqDqv63y1x0mm2VjOl8GOw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "System.Diagnostics.EventLog": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "WnFvZP+Y+lfeNFKPK/+mBpaCC7EeBDlobrQOqnP7rrw/+vE7yu8Rjczum1xbC0F/8cAHafog84DMp9200akMNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "G6VVwywpJI4XIobetGHwg7wDOYC2L2XBYdtskxLaKF/Ynb5QBwLl7Q//wxAR2aVCLkMpoQrjSP9VoORkyddsNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "pL78/Im7O3WmxHzlKUsWTYchKL881udU7E26gCD3T0+/tPhWVfjPwMzfN/MRKU7aoFYcOiqcG2k1QTlH5woWow==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "9.0.9",
-        "contentHash": "z4pyMePOrl733ltTowbN565PxBw1oAr8IHmIXNDiDqd22nFpYltX9KhrNC/qBWAG1/Zx5MHX+cOYhWJQYCO/iw=="
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
       },
       "Microsoft.QualityTools.Testing.Fakes": {
         "type": "Transitive",
@@ -457,6 +731,15 @@
         "resolved": "18.0.1",
         "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
       },
+      "ModelContextProtocol.Core": {
+        "type": "Transitive",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "33V1Druluweou6x2LN6MSMbhiwHOYZxTUEJ1okFKjYDRIthctTVe0EJi//nifl4MRld2b5D5LnuV9sezz54p6g==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
       "MSTest.Analyzers": {
         "type": "Transitive",
         "resolved": "4.0.2",
@@ -493,8 +776,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "9.0.9",
-        "contentHash": "wpsUfnyv8E5K4WQaok6weewvAbQhcLwXFcHBm5U0gdEaBs85N//ssuYvRPFWwz2rO/9/DFP3A1sGMzUFBj8y3w=="
+        "resolved": "10.0.1",
+        "contentHash": "xfaHEHVDkMOOZR5S6ZGezD0+vekdH1Nx/9Ih8/rOqOGSOk1fxiN3u94bYkBW/wigj0Uw2Wt3vvRj9mtYdgwEjw=="
       },
       "System.Reflection.TypeExtensions": {
         "type": "Transitive",
@@ -518,6 +801,16 @@
         "type": "Transitive",
         "resolved": "3.0.0",
         "contentHash": "fFYBEVmVlyoeq2dhjM8OR3OCr+ZNCL8E7nEePCZyH2BVo3ky5lHZZiF0PcWwOJmRTyIA/6c0716DfHKNB5oKKg=="
+      },
+      "verifiable": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting": "[10.0.1, )",
+          "ModelContextProtocol": "[0.5.0-preview.1, )",
+          "System.CommandLine": "[2.0.1, )",
+          "Verifiable.Core": "[0.0.0, )",
+          "Verifiable.Tpm": "[0.0.0, )"
+        }
       },
       "verifiable.bouncycastle": {
         "type": "Project",


### PR DESCRIPTION
- Replacing Spectre with System.CommandLine is done to reduce dependencies.
- At the same time, also first-pass MCP server is added.