### PR TITLE
Disabling TPM unit tests on MacOS (#466)

### DIFF
--- a/test/Verifiable.Tests/Tpm/TpmCommandParserTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmCommandParserTests.cs
@@ -33,8 +33,7 @@ namespace Verifiable.Tests.Tpm
             Assert.AreEqual(1u, BinaryPrimitives.ReadUInt32BigEndian(isFipsCommandBreakDown[5].TpmInstruction));
         }
 
-        
-        [SkipOnCiTestMethod]
+        [RunOnlyOnPlatformSkipOnCiTestMethod(platforms: [Platforms.Windows, Platforms.Linux])]
         public void GetSupportedAlgorithmsCommandSucceeds()
         {
             var command = new GetCapabilityCommand();

--- a/test/Verifiable.Tests/TpmTests.cs
+++ b/test/Verifiable.Tests/TpmTests.cs
@@ -24,14 +24,14 @@ namespace Verifiable.Tests.Tpm
         /// <summary>
         /// Checks that calling supported TPM platforms does not throw.
         /// </summary>
-        [SkipOnCiTestMethod]
+        [RunOnlyOnPlatformSkipOnCiTestMethod(platforms: [Platforms.Windows, Platforms.Linux])]
         public void TpmIsPlatformSupported()
         {
             _ = TpmExtensions.IsTpmPlatformSupported();
         }
 
 
-        [SkipOnCiTestMethod]
+        [RunOnlyOnPlatformSkipOnCiTestMethod(platforms: [Platforms.Windows, Platforms.Linux])]
         public void TpmGetPropertiesSucceeds()
         {
             var tpmInfo = TpmWrapper.Tpm.GetAllTpmInfo();
@@ -44,7 +44,7 @@ namespace Verifiable.Tests.Tpm
         }
 
 
-        [SkipOnCiTestMethod]
+        [RunOnlyOnPlatformSkipOnCiTestMethod(platforms: [Platforms.Windows, Platforms.Linux])]
         public void TpmGetPcrBanksSucceeds()
         {
             var pcrBanks = TpmWrapper.Tpm.GetPcrBanks();
@@ -56,7 +56,7 @@ namespace Verifiable.Tests.Tpm
             }
         }
 
-        [SkipOnCiTestMethod]
+        [RunOnlyOnPlatformSkipOnCiTestMethod(platforms: [Platforms.Windows, Platforms.Linux])]
         public void HashCheck()
         {
             byte[] hashData = TpmWrapper.Tpm.Hash([1, 2, 3],   // Data to hash


### PR DESCRIPTION
* TPM module is not supported by Apple.