### PR TITLE
Updating EllipticCurveTestData to pvovide only crypto algorythm inste…

### DIFF
--- a/test/Verifiable.Tests/Cryptography/MicrosoftKeyCreatorTests.cs
+++ b/test/Verifiable.Tests/Cryptography/MicrosoftKeyCreatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using Verifiable.Cryptography;
 using Verifiable.Microsoft;
+using Verifiable.Tests.TestInfrastructure;
 
 namespace Verifiable.Tests.Cryptography
 {
@@ -41,7 +42,7 @@ namespace Verifiable.Tests.Cryptography
         }
 
 
-        [TestMethod]
+        [SkipOnMacOSTestMethod(Reason = "The secP256k1 curve is not supported on macOS.")]
         public async ValueTask Secp256k1SignatureVerifies()
         {
             var compressedKeys = MicrosoftKeyMaterialCreator.CreateSecp256k1Keys(SensitiveMemoryPool<byte>.Shared);

--- a/test/Verifiable.Tests/Cryptography/MultibaseEncodingTests.cs
+++ b/test/Verifiable.Tests/Cryptography/MultibaseEncodingTests.cs
@@ -121,8 +121,14 @@ namespace Verifiable.Tests.Cryptography
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(EllipticCurveTheoryData.GetEllipticCurveTestData), typeof(EllipticCurveTheoryData))]
-        public void EllipticCurvesWithMultibaseBtc58Succeeds(EllipticCurveTestData td)
+        public void EllipticCurvesWithMultibaseBtc58Succeeds(EllipticCurveTestCase testCase)
         {
+            if(OperatingSystem.IsMacOS() && testCase.CurveIdentifier == CryptoAlgorithm.Secp256k1)
+            {
+                return; // The secP256k1 curve is not supported on macOS.
+            }
+
+            var td = EllipticCurveTheoryData.CreateEllipticCurveTestData(testCase);
             var compressed = EllipticCurveUtilities.Compress(td.PublicKeyMaterialX, td.PublicKeyMaterialY);
 
             var multibaseEncodedPublicKey = MultibaseSerializer.Encode(
@@ -239,7 +245,7 @@ namespace Verifiable.Tests.Cryptography
         [TestMethod]
         public void P256KeyCreationTest()
         {
-            var keys = PublicPrivateKeyMaterialExtensions.Create(SensitiveMemoryPool<byte>.Shared, MicrosoftKeyMaterialCreator.CreateP256Keys);
+            var keys = MicrosoftKeyMaterialCreator.CreateP256Keys(SensitiveMemoryPool<byte>.Shared);
 
             //Use high-level API for encoding.
             var multibaseEncodedPublicKey = MultibaseSerializer.EncodeKey(


### PR DESCRIPTION
…ad of fully initialized test data object (#468)

This prevents test failure on DynamicData generation and allows to handle unsupported Secp256k1 algorythm on Mac gracefully inside test body.