### PR TITLE
OID4VP credential-status gate and RFC 7662 introspection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,9 @@ env:
     api.clearlydefined.io:443
     aka.ms:443
     api.github.com:443
+    *.actions.githubusercontent.com:443
     api.nuget.org:443
+    www.nuget.org:443
     builds.dotnet.microsoft.com:443
     ci.dot.net:443
     pkgs.dev.azure.com:443
@@ -232,7 +234,7 @@ jobs:
     # This step is run always (e.g. also for non-PRs) so the results can be inspected on the command line too.
     - name: ReportGenerator
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: dotnet reportgenerator -filefilters:'-**/obj/**;-**/*.g.cs' -assemblyfilters:'+Verifiable*' -reports:'${{ github.workspace }}/reports/coverage.cobertura.xml' -targetdir:'${{ github.workspace }}/reports/coverage/' -reporttypes:'HtmlInline;Cobertura;MarkdownSummary'
+      run: dotnet reportgenerator -filefilters:'-**/obj/**;-**/*.g.cs' -assemblyfilters:'+Verifiable*' -reports:'${{ github.workspace }}/reports/coverage.cobertura.xml' -targetdir:'${{ github.workspace }}/reports/coverage/' -reporttypes:'HtmlInline;Cobertura'
 
     - name: Create test summary
       if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
@@ -240,13 +242,31 @@ jobs:
       with:
         trx_files: '${{ github.workspace }}/reports/**/*.trx'
 
-    - name: Publish coverage summary
-      if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
-      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+    # The full file-by-file coverage report is uploaded as an artifact rather than posted to
+    # the PR — the per-file table was too long to be useful inline. Only the headline line/
+    # branch numbers go to the run's job summary.
+    - name: Upload coverage report
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        header: Report
-        path: '${{ github.workspace }}/reports/coverage/Summary.md'
-        recreate: true
+        name: coverage-report
+        path: '${{ github.workspace }}/reports/coverage/'
+
+    - name: Coverage headline to job summary
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      shell: bash
+      run: |
+        xml='${{ github.workspace }}/reports/coverage.cobertura.xml'
+        lineRate=$(grep -m1 '<coverage ' "$xml" | grep -oE 'line-rate="[0-9.]+"' | grep -oE '[0-9.]+')
+        branchRate=$(grep -m1 '<coverage ' "$xml" | grep -oE 'branch-rate="[0-9.]+"' | grep -oE '[0-9.]+')
+        linePct=$(awk -v v="$lineRate" 'BEGIN { printf "%.1f", v * 100 }')
+        branchPct=$(awk -v v="$branchRate" 'BEGIN { printf "%.1f", v * 100 }')
+        {
+          echo "### Coverage"
+          echo ""
+          echo "- Line: ${linePct}%"
+          echo "- Branch: ${branchPct}%"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Update MCP server manifest version
       if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' }}
@@ -278,7 +298,7 @@ jobs:
         done
 
     - name: Generate artifact attestation
-      if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' && github.actor != 'dependabot[bot]' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'lumoin' && github.actor != 'dependabot[bot]' && github.event.repository.private == false }}
       uses: lumoin/trusted-devsecops/.github/actions/sign-artifact@bd2b7f91e73d758f3126562d6a569fc0f31814ee
       with:
         subject-path: './nupkgs/*.nupkg'
@@ -621,7 +641,7 @@ jobs:
         done
 
     - name: Generate artifact attestation for CLI packages
-      if: ${{ github.actor != 'dependabot[bot]' }}
+      if: ${{ github.actor != 'dependabot[bot]' && github.event.repository.private == false }}
       uses: lumoin/trusted-devsecops/.github/actions/sign-artifact@bd2b7f91e73d758f3126562d6a569fc0f31814ee
       with:
         subject-path: './nupkgs/*.nupkg'
@@ -692,6 +712,10 @@ jobs:
     needs: [ build, pack-cli-pointer ]
     if: ${{ github.event_name == 'release' && github.repository_owner == 'lumoin' }}
     runs-on: ubuntu-latest
+    # Bind publishing to the "Release" deployment environment so the OIDC token carries the
+    # environment claim nuget.org trusted publishing requires, and deployments are recorded
+    # against it.
+    environment: Release
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411

--- a/src/Verifiable.Core/StatusList/CredentialStatusGate.cs
+++ b/src/Verifiable.Core/StatusList/CredentialStatusGate.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Verifiable.Core.StatusList;
+
+/// <summary>
+/// Resolves the Status List Token a credential's <see cref="StatusListReference"/> points at,
+/// already cryptographically verified and parsed. The caller — an RP server, a peer wallet, or an
+/// agent — owns the fetch, the signature/trust verification of the status list issuer, and any
+/// caching (in an Orleans-style deployment this is naturally a status-list grain that fetches once
+/// and fans the verified token out to many verifiers). The library does no transport here.
+/// </summary>
+/// <param name="uri">The <c>uri</c> of the Status List Token (the credential's <c>status_list.uri</c>).</param>
+/// <param name="cancellationToken">A cancellation token.</param>
+/// <returns>The verified Status List Token.</returns>
+public delegate ValueTask<StatusListToken> ResolveVerifiedStatusListTokenDelegate(
+    string uri,
+    CancellationToken cancellationToken = default);
+
+
+/// <summary>
+/// The outcome of checking a credential's status against its referenced status list.
+/// </summary>
+public sealed record CredentialStatusOutcome
+{
+    /// <summary>The raw status value read from the list at the credential's index.</summary>
+    public required byte Status { get; init; }
+
+    /// <summary>
+    /// Whether the credential is valid, i.e. <see cref="Status"/> is <see cref="StatusTypes.Valid"/>
+    /// (<c>0x00</c>). Any other value — revoked (<c>0x01</c>), suspended (<c>0x02</c>), or
+    /// application-specific — is not valid. Inspect <see cref="Status"/> to distinguish them.
+    /// </summary>
+    public required bool IsValid { get; init; }
+}
+
+
+/// <summary>
+/// The verifier-agnostic revocation gate for the IETF Token Status List: given a credential's
+/// status reference, resolve its (already verified) Status List Token and read the status bit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A valid issuer signature only proves a credential was genuinely issued; it does not prove the
+/// credential is still valid <em>now</em>. This gate is the "is it still valid?" step, run after
+/// signature and holder-binding verification. It is a pure, static, allocation-light function — it
+/// holds no state and does no I/O — so it runs identically wherever the verifier role lives: an RP
+/// server, a peer wallet in a P2P/proximity exchange, or an agent (or wallet) hosted as an actor in
+/// a cluster. Coupling it to any one server pipeline would lock those other verifiers out; keeping
+/// it here, taking a resolver the caller supplies, keeps it universal.
+/// </para>
+/// <para>
+/// Resolution, signature verification of the status list, trust, and caching are the caller's
+/// concern, expressed through <see cref="ResolveVerifiedStatusListTokenDelegate"/>. The gate only
+/// reads the bit via <see cref="StatusListValidation.GetStatus(StatusListToken, StatusListReference, DateTimeOffset)"/>,
+/// which also enforces the token's subject match, expiry, and index bounds — so a token whose
+/// subject does not match the reference URI, an expired list, or an out-of-range index surfaces as
+/// a <see cref="StatusListValidationException"/> (fail-closed: an undeterminable status is not a
+/// pass).
+/// </para>
+/// </remarks>
+public static class CredentialStatusGate
+{
+    /// <summary>
+    /// Resolves the credential's verified Status List Token and reads its status.
+    /// </summary>
+    /// <param name="reference">The credential's status reference (<c>status_list</c> <c>idx</c>/<c>uri</c>).</param>
+    /// <param name="resolveVerifiedStatusListToken">The caller-supplied resolver yielding the verified token.</param>
+    /// <param name="currentTime">The current time for the token's expiry check.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The status value and whether the credential is valid.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="resolveVerifiedStatusListToken"/> resolves a <see langword="null"/> token, or the delegate is <see langword="null"/>.</exception>
+    /// <exception cref="StatusListValidationException">Thrown when the token's subject mismatches, the list has expired, or the index is out of bounds.</exception>
+    public static async ValueTask<CredentialStatusOutcome> CheckAsync(
+        StatusListReference reference,
+        ResolveVerifiedStatusListTokenDelegate resolveVerifiedStatusListToken,
+        DateTimeOffset currentTime,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resolveVerifiedStatusListToken);
+
+        StatusListToken token = await resolveVerifiedStatusListToken(reference.Uri, cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(token);
+
+        byte status = StatusListValidation.GetStatus(token, reference, currentTime);
+
+        return new CredentialStatusOutcome
+        {
+            Status = status,
+            IsValid = status == StatusTypes.Valid
+        };
+    }
+}

--- a/src/Verifiable.OAuth/AuthCode/AuthCodeEndpoints.cs
+++ b/src/Verifiable.OAuth/AuthCode/AuthCodeEndpoints.cs
@@ -11,6 +11,7 @@ using Verifiable.OAuth.AuthCode.Server;
 using Verifiable.OAuth.AuthCode.Server.States;
 using Verifiable.OAuth.Client;
 using Verifiable.OAuth.Dpop;
+using Verifiable.OAuth.Introspection;
 using Verifiable.OAuth.Jar;
 using Verifiable.OAuth.Oid4Vp;
 using Verifiable.OAuth.Oidc;
@@ -153,7 +154,14 @@ public static class AuthCodeEndpoints
             candidates.Add(BuildRevocation());
         }
 
-        if(registration.IsCapabilityAllowed(WellKnownCapabilityIdentifiers.OAuthTokenIntrospection))
+        //RFC 7662 introspection materializes only when the capability is allowed
+        //AND both the introspection seam and the client-authentication seam are
+        //wired: an endpoint that cannot authenticate the caller would leak token
+        //state, and one with no store to read could only answer active:false —
+        //both fail-closed, like revocation above.
+        if(registration.IsCapabilityAllowed(WellKnownCapabilityIdentifiers.OAuthTokenIntrospection)
+            && context.Server?.Integration.IntrospectTokenAsync is not null
+            && context.Server?.Integration.ValidateClientCredentialsAsync is not null)
         {
             candidates.Add(BuildIntrospection());
         }
@@ -2420,8 +2428,13 @@ public static class AuthCodeEndpoints
             Name = WellKnownEndpointNames.AuthCodeIntrospect,
             HttpMethod = WellKnownHttpMethods.Post,
             Capability = WellKnownCapabilityIdentifiers.OAuthTokenIntrospection,
-            StartsNewFlow = false,
-            Kind = FlowKind.AuthCodeServer,
+            //RFC 7662 introspection is stateless — a single request that reads a
+            //token's status and returns, with no multi-step flow and no correlation
+            //key to resolve. It uses the same stateless shape as revocation
+            //(StartsNewFlow + FlowKind.Stateless), not the stateful AuthCodeServer
+            //path that would demand a flow handle the request never carries.
+            StartsNewFlow = true,
+            Kind = FlowKind.Stateless,
             DiscoveryMetadataKey = AuthorizationServerMetadataParameterNames.IntrospectionEndpoint,
 
             //Acceptance test: POST to /introspect with a token body parameter
@@ -2445,13 +2458,167 @@ public static class AuthCodeEndpoints
                 return ValueTask.FromResult<MatchPayload?>(MatchPayload.Empty);
             },
 
-            BuildInputAsync = static (fields, context, currentState, ct) =>
-                ValueTask.FromResult<(OAuthFlowInput?, ServerHttpResponse?)>(
-                    (null, ServerHttpResponse.ServerError(
-                        OAuthErrors.ServerError, "Introspection not yet implemented."))),
+            BuildInputAsync = static async (fields, context, currentState, ct) =>
+            {
+                AuthorizationServer server = context.Server!;
+
+                ClientRecord? registration = context.Registration;
+                if(registration is null)
+                {
+                    return (null, ServerHttpResponse.Unauthorized(
+                        OAuthErrors.InvalidClient, "Unknown client."));
+                }
+
+                //RFC 7662 §2.3: a caller authenticating with client credentials that
+                //fail authentication gets HTTP 401. The candidate gate guarantees the
+                //seam is wired.
+                bool clientAuthenticated = await server.Integration.ValidateClientCredentialsAsync!(
+                    context.IncomingRequest, fields, registration, context, ct).ConfigureAwait(false);
+                if(!clientAuthenticated)
+                {
+                    return (null, ServerHttpResponse.Unauthorized(
+                        OAuthErrors.InvalidClient, "Client authentication failed."));
+                }
+
+                //RFC 7662 §2.1: token is REQUIRED. The matcher already guaranteed its
+                //presence; the guard keeps the contract explicit and local.
+                if(!fields.TryGetValue(OAuthRequestParameterNames.Token, out string? token)
+                    || string.IsNullOrEmpty(token))
+                {
+                    return (null, ServerHttpResponse.BadRequest(
+                        OAuthErrors.InvalidRequest, "Missing token parameter."));
+                }
+
+                fields.TryGetValue(OAuthRequestParameterNames.TokenTypeHint, out string? tokenTypeHint);
+
+                //RFC 7662 §2.2: the application reads its own token store and returns the
+                //token's metadata, or an inactive result for an unknown / expired / revoked
+                //token (or one this caller may not see). An unrecognized token_type_hint is
+                //a hint, not an error. A well-formed, authorized query for an inactive token
+                //is NOT an error (RFC 7662 §2.3) — it answers 200 with {"active":false}.
+                TokenIntrospectionResult result = await server.Integration.IntrospectTokenAsync!(
+                    token, tokenTypeHint, registration, context, ct).ConfigureAwait(false);
+
+                //RFC 7662 §2.2: a JSON object in application/json. The library owns the wire
+                //shape and the rule that an inactive token discloses nothing further. The
+                //response is left cacheable per RFC 7662 §4 (cache up to the token's exp).
+                string responseJson = SerializeIntrospectionResponse(result);
+
+                return (null, ServerHttpResponse.Ok(responseJson, WellKnownMediaTypes.Application.Json));
+            },
             BuildResponse = static (state, _, _) =>
                 ServerHttpResponse.ServerError(OAuthErrors.ServerError, "Not reached.")
         };
+
+
+    /// <summary>
+    /// Serialises a <see cref="TokenIntrospectionResult"/> to its RFC 7662 §2.2
+    /// <c>application/json</c> response body. <c>active</c> is always present; every other
+    /// member is written only when the token is active and the value is supplied. An
+    /// inactive token yields exactly <c>{"active":false}</c> — RFC 7662 §2.2 directs the
+    /// server not to disclose any further information about it, including why it is inactive.
+    /// </summary>
+    private static string SerializeIntrospectionResponse(TokenIntrospectionResult result)
+    {
+        StringBuilder sb = JsonAppender.Rent();
+        try
+        {
+            sb.Append('{');
+            bool first = true;
+            JsonAppender.AppendBoolField(sb, "active", result.IsActive, ref first);
+
+            if(result.IsActive)
+            {
+                if(result.Scope is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "scope", result.Scope, ref first);
+                }
+
+                if(result.ClientId is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "client_id", result.ClientId, ref first);
+                }
+
+                if(result.Username is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "username", result.Username, ref first);
+                }
+
+                if(result.TokenType is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "token_type", result.TokenType, ref first);
+                }
+
+                if(result.ExpiresAt is { } expiresAt)
+                {
+                    JsonAppender.AppendInt64Field(sb, "exp", expiresAt.ToUnixTimeSeconds(), ref first);
+                }
+
+                if(result.IssuedAt is { } issuedAt)
+                {
+                    JsonAppender.AppendInt64Field(sb, "iat", issuedAt.ToUnixTimeSeconds(), ref first);
+                }
+
+                if(result.NotBefore is { } notBefore)
+                {
+                    JsonAppender.AppendInt64Field(sb, "nbf", notBefore.ToUnixTimeSeconds(), ref first);
+                }
+
+                if(result.Subject is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "sub", result.Subject, ref first);
+                }
+
+                //RFC 7662 §2.2 aud: "string identifier or list of string identifiers" — a
+                //single audience is written as a JSON string, multiple as an array, both
+                //valid per RFC 7519.
+                if(result.Audience is { Count: > 0 } audience)
+                {
+                    if(audience.Count == 1)
+                    {
+                        JsonAppender.AppendStringField(sb, "aud", audience[0], ref first);
+                    }
+                    else
+                    {
+                        JsonAppender.AppendStringArrayField(sb, "aud", audience, ref first);
+                    }
+                }
+
+                if(result.Issuer is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "iss", result.Issuer, ref first);
+                }
+
+                if(result.JwtId is not null)
+                {
+                    JsonAppender.AppendStringField(sb, "jti", result.JwtId, ref first);
+                }
+
+                //RFC 7662 §2.2: service-specific extension members as further top-level
+                //members, each serialised by its runtime type. active is always present, so
+                //a leading comma is always required here.
+                if(result.AdditionalClaims is not null)
+                {
+                    foreach(KeyValuePair<string, object> claim in result.AdditionalClaims)
+                    {
+                        sb.Append(',');
+                        sb.Append('"');
+                        JsonAppender.AppendEscapedString(sb, claim.Key);
+                        sb.Append("\":");
+                        JsonAppender.AppendValue(sb, claim.Value);
+                    }
+                }
+            }
+
+            sb.Append('}');
+
+            return sb.ToString();
+        }
+        finally
+        {
+            JsonAppender.Return(sb);
+        }
+    }
 
 
     /// <summary>

--- a/src/Verifiable.OAuth/Introspection/TokenIntrospectionResult.cs
+++ b/src/Verifiable.OAuth/Introspection/TokenIntrospectionResult.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Verifiable.OAuth.Introspection;
+
+/// <summary>
+/// The application's answer to an OAuth 2.0 Token Introspection request
+/// (<see href="https://www.rfc-editor.org/rfc/rfc7662#section-2.2">RFC 7662 §2.2</see>):
+/// the token's metadata as the authorization server knows it, projected onto the
+/// specification's top-level response members. The application produces this from its
+/// own token store; the library owns the wire shape, serialising it to the
+/// <c>application/json</c> response body.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IsActive"/> is the one REQUIRED member. When it is <see langword="false"/>
+/// — the token is unknown, expired, revoked, or this caller may not see it — the library
+/// emits <c>{"active":false}</c> and nothing else, honouring RFC 7662 §2.2's instruction
+/// that the server SHOULD NOT disclose any further information about an inactive token
+/// (including why it is inactive). Every other member here is therefore only ever written
+/// when <see cref="IsActive"/> is <see langword="true"/>; an application returning an
+/// inactive result can use <see cref="Inactive"/> and ignore the rest.
+/// </para>
+/// <para>
+/// The standard members are typed; <see cref="AdditionalClaims"/> carries any
+/// service-specific extension members the deployment adds (RFC 7662 §2.2 permits these as
+/// top-level members) — for instance the <c>acr</c> and <c>auth_time</c> an RFC 9470
+/// step-up deployment records on its access tokens, or a <c>cnf</c> proof-of-possession
+/// confirmation.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("TokenIntrospectionResult IsActive={IsActive} Subject={Subject}")]
+public sealed record TokenIntrospectionResult
+{
+    /// <summary>
+    /// RFC 7662 §2.2 <c>active</c> (REQUIRED): whether the presented token is currently
+    /// active — generally that the authorization server issued it, the resource owner has
+    /// not revoked it, and it is within its validity window.
+    /// </summary>
+    public required bool IsActive { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>scope</c>: the space-separated scopes associated with the token
+    /// (OAuth 2.0 §3.3 format), or <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? Scope { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>client_id</c>: the client the token was issued to, or
+    /// <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>username</c>: a human-readable identifier for the resource owner
+    /// who authorized the token, or <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>token_type</c>: the token type (OAuth 2.0 §5.1), or
+    /// <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? TokenType { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>exp</c>: when the token expires. Serialised as a JWT NumericDate
+    /// (seconds since the Unix epoch). <see langword="null"/> when not surfaced.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>iat</c>: when the token was issued. Serialised as a JWT NumericDate.
+    /// <see langword="null"/> when not surfaced.
+    /// </summary>
+    public DateTimeOffset? IssuedAt { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>nbf</c>: the earliest time the token may be used. Serialised as a
+    /// JWT NumericDate. <see langword="null"/> when not surfaced.
+    /// </summary>
+    public DateTimeOffset? NotBefore { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>sub</c>: the token's subject, usually a machine-readable identifier
+    /// of the resource owner, or <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>aud</c>: the token's intended audience(s). A single entry is written
+    /// as a JSON string and multiple entries as a JSON array, both valid per RFC 7519.
+    /// <see langword="null"/> or empty when not surfaced.
+    /// </summary>
+    public IReadOnlyList<string>? Audience { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>iss</c>: the issuer of the token (a JWT StringOrURI), or
+    /// <see langword="null"/> when not surfaced.
+    /// </summary>
+    public string? Issuer { get; init; }
+
+    /// <summary>
+    /// RFC 7662 §2.2 <c>jti</c>: the token's unique identifier, or <see langword="null"/>
+    /// when not surfaced.
+    /// </summary>
+    public string? JwtId { get; init; }
+
+    /// <summary>
+    /// Service-specific extension members written as additional top-level members of the
+    /// response object (RFC 7662 §2.2). Each value is serialised by its runtime type
+    /// (string, boolean, number, nested object, or array). <see langword="null"/> when the
+    /// deployment surfaces no extensions.
+    /// </summary>
+    public IReadOnlyDictionary<string, object>? AdditionalClaims { get; init; }
+
+    /// <summary>
+    /// The canonical inactive result — <c>{"active":false}</c> — for a token that is
+    /// unknown, expired, revoked, or that the calling resource may not introspect
+    /// (RFC 7662 §2.2 / §2.3).
+    /// </summary>
+    public static TokenIntrospectionResult Inactive { get; } = new() { IsActive = false };
+}

--- a/src/Verifiable.OAuth/Oid4Vp/Server/SdJwtVpTokenVerification.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/Server/SdJwtVpTokenVerification.cs
@@ -5,6 +5,7 @@ using Verifiable.Cryptography;
 using Verifiable.Cryptography.Context;
 using Verifiable.JCose;
 using Verifiable.Core.Model.SelectiveDisclosure;
+using Verifiable.Core.StatusList;
 
 namespace Verifiable.OAuth.Oid4Vp.Server;
 
@@ -113,6 +114,7 @@ public static class SdJwtVpTokenVerification
         string? iss;
         string? sdAlg;
         Dictionary<string, object>? jwkDict;
+        string? statusObject;
 
         {
             string[] issuerParts = token.IssuerSigned.Split('.');
@@ -123,7 +125,14 @@ public static class SdJwtVpTokenVerification
             sdAlg = JwkJsonReader.ExtractStringValue(issuerPayload, "_sd_alg"u8);
             jwkDict = JwkJsonReader.ExtractNestedObjectProperties(
                 issuerPayload, "cnf"u8, "jwk"u8);
+
+            //IETF Token Status List section 6: the Referenced Token MAY carry a status claim with a
+            //status_list reference. Slice the status object span here; parsing happens off-span below.
+            statusObject = JwkJsonReader.ExtractObjectAsString(issuerPayload, "status"u8);
         }
+
+        //The credential's status reference (idx/uri), surfaced for the verifier's revocation gate.
+        StatusListReference? credentialStatus = ParseStatusListReference(statusObject);
 
         //Resolve the issuer's public key from the trust framework.
         PublicKeyMemory? issuerPublicKey = iss is not null ? resolveIssuerKey(iss) : null;
@@ -275,6 +284,7 @@ public static class SdJwtVpTokenVerification
             KbJwtSignatureValid = kbJwtSignatureValid,
             CredentialSignatureValid = credentialSignatureValid,
             CredentialIssuer = iss,
+            CredentialStatus = credentialStatus,
             SdHashValid = sdHashValid,
             SessionTranscriptValid = true,
             KbJwtTransactionDataHashes = kbTransactionDataHashes,
@@ -290,5 +300,36 @@ public static class SdJwtVpTokenVerification
             MinimumDisclosureSaltLengthBytes = minimumSaltLength,
             SaltReused = saltReused
         };
+    }
+
+
+    //Parses the IETF Token Status List reference (status.status_list = {idx, uri}) from the
+    //already-sliced status object JSON. Span-based throughout to keep this class serialization-free;
+    //the two small re-encodes only run when a status claim is actually present.
+    internal static StatusListReference? ParseStatusListReference(string? statusObjectJson)
+    {
+        if(statusObjectJson is null)
+        {
+            return null;
+        }
+
+        string? statusListObject = JwkJsonReader.ExtractObjectAsString(
+            Encoding.UTF8.GetBytes(statusObjectJson), "status_list"u8);
+        if(statusListObject is null)
+        {
+            return null;
+        }
+
+        ReadOnlySpan<byte> statusListBytes = Encoding.UTF8.GetBytes(statusListObject);
+        string? uri = JwkJsonReader.ExtractStringValue(statusListBytes, "uri"u8);
+        if(uri is null
+            || !JwkJsonReader.TryExtractLongValue(statusListBytes, "idx"u8, out long index)
+            || index < 0
+            || index > int.MaxValue)
+        {
+            return null;
+        }
+
+        return new StatusListReference((int)index, uri);
     }
 }

--- a/src/Verifiable.OAuth/Oid4Vp/Server/VpTokenParsed.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/Server/VpTokenParsed.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Verifiable.Core.Model.SelectiveDisclosure;
+using Verifiable.Core.StatusList;
 
 namespace Verifiable.OAuth.Oid4Vp.Server;
 
@@ -111,4 +112,13 @@ public sealed record VpTokenParsed
     /// or no reuse occurred.
     /// </summary>
     public bool SaltReused { get; init; }
+
+    /// <summary>
+    /// The IETF Token Status List reference (<c>status.status_list = {idx, uri}</c>) extracted from
+    /// the credential's issuer payload, or <see langword="null"/> when the credential carries no
+    /// status claim. A verifier — RP server, peer wallet, or agent — passes this to
+    /// <see cref="StatusList.CredentialStatusGate"/> to check revocation; surfacing it here keeps
+    /// the fetch and trust of the status list the caller's concern, not the parser's.
+    /// </summary>
+    public StatusListReference? CredentialStatus { get; init; }
 }

--- a/src/Verifiable.OAuth/Server/AuthorizationServerDelegates.cs
+++ b/src/Verifiable.OAuth/Server/AuthorizationServerDelegates.cs
@@ -754,6 +754,51 @@ public delegate ValueTask RevokeTokenDelegate(
 
 
 /// <summary>
+/// Introspects a token at the token introspection endpoint
+/// (<see href="https://www.rfc-editor.org/rfc/rfc7662">RFC 7662</see>) on behalf
+/// of an authenticated protected resource, returning the token's metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Invoked after the endpoint has authenticated the caller via
+/// <see cref="ValidateClientCredentialsDelegate"/>. The application looks the
+/// presented token up in its own store and returns a
+/// <see cref="Introspection.TokenIntrospectionResult"/> describing it. The same store the
+/// per-call decision seams (<see cref="EvaluateAccessDelegate"/>,
+/// <see cref="LoadClientRegistrationDelegate"/>) read to reject a revoked token is what
+/// decides liveness here, so an introspection answer and an enforcement decision converge
+/// on one piece of state.
+/// </para>
+/// <para>
+/// Per <see href="https://www.rfc-editor.org/rfc/rfc7662#section-2.2">RFC 7662 §2.2</see>
+/// a token that is unknown, expired, revoked, or that this caller may not see is NOT an
+/// error: the application returns <see cref="Introspection.TokenIntrospectionResult.Inactive"/>
+/// (the library answers HTTP 200 with <c>{"active":false}</c> and discloses nothing
+/// further). The application MUST scope its answer to what
+/// <paramref name="registration"/> is entitled to learn — RFC 7662 §2.2 lets the server
+/// limit, or withhold, a token's details per requesting resource.
+/// </para>
+/// <para>
+/// <paramref name="tokenTypeHint"/> carries the RFC 7662 §2.1 <c>token_type_hint</c> when
+/// present — an optimization the application MAY use to locate the token faster; an
+/// unrecognized hint MUST NOT cause a failure.
+/// </para>
+/// </remarks>
+/// <param name="token">The token to introspect, exactly as presented on the wire.</param>
+/// <param name="tokenTypeHint">The <c>token_type_hint</c> form value, or <see langword="null"/> when omitted.</param>
+/// <param name="registration">The authenticated protected resource making the request.</param>
+/// <param name="context">The per-request context bag.</param>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>The token's metadata, or an inactive result when it is unknown or not disclosable.</returns>
+public delegate ValueTask<Introspection.TokenIntrospectionResult> IntrospectTokenDelegate(
+    string token,
+    string? tokenTypeHint,
+    ClientRecord registration,
+    ExchangeContext context,
+    CancellationToken cancellationToken);
+
+
+/// <summary>
 /// Parses a Global Token Revocation request body
 /// (<see href="https://datatracker.ietf.org/doc/draft-parecki-oauth-global-token-revocation/">draft-parecki-oauth-global-token-revocation §3</see>)
 /// into the neutral <see cref="Logout.GlobalTokenRevocationRequest"/> — a single

--- a/src/Verifiable.OAuth/Server/AuthorizationServerIntegration.cs
+++ b/src/Verifiable.OAuth/Server/AuthorizationServerIntegration.cs
@@ -495,6 +495,19 @@ public sealed class AuthorizationServerIntegration
     public RevokeTokenDelegate? RevokeTokenAsync { get; set; }
 
     /// <summary>
+    /// Introspects a token at the RFC 7662 introspection endpoint on behalf of an
+    /// authenticated protected resource. The endpoint activates only when the
+    /// <see cref="WellKnownCapabilityIdentifiers.OAuthTokenIntrospection"/> capability
+    /// is allowed and BOTH this seam and <see cref="ValidateClientCredentialsAsync"/>
+    /// are wired — an introspection endpoint that cannot authenticate the caller would
+    /// leak token state to anyone, and one that cannot read the token store could only
+    /// answer <c>active:false</c>, misleading a resource into rejecting live tokens. The
+    /// application owns the token store; the library owns the wire shape and the
+    /// inactive-discloses-nothing rule.
+    /// </summary>
+    public IntrospectTokenDelegate? IntrospectTokenAsync { get; set; }
+
+    /// <summary>
     /// Parses a Global Token Revocation request body
     /// (draft-parecki-oauth-global-token-revocation §3) into the neutral
     /// <see cref="Logout.GlobalTokenRevocationRequest"/>. Required when

--- a/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
+++ b/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Verifiable.BouncyCastle;
 using Verifiable.Core;
 using Verifiable.Core.Assessment;
+using Verifiable.Core.StatusList;
 using Verifiable.Core.Dcql;
 using Verifiable.Core.Model.Dcql;
 using Verifiable.Core.Model.SelectiveDisclosure;
@@ -31,6 +32,8 @@ using Verifiable.Tests.TestDataProviders;
 using System.Collections.Immutable;
 using Verifiable.OAuth.Server;
 using Verifiable.Tests.TestInfrastructure;
+
+using StatusListType = Verifiable.Core.StatusList.StatusList;
 
 namespace Verifiable.Tests.OAuth;
 
@@ -1342,7 +1345,7 @@ internal sealed class Oid4VpFlowIntegrationTests
 
 
     private async ValueTask<(string SerializedSdJwt, PrivateKeyMemory HolderPrivateKey, PublicKeyMemory IssuerPublicKey)>
-        IssuePidCredentialWithClaimsAsync(string givenName, string familyName, CancellationToken cancellationToken)
+        IssuePidCredentialWithClaimsAsync(string givenName, string familyName, CancellationToken cancellationToken, StatusListReference? status = null)
     {
         var issuerKeys = TestKeyMaterialProvider.CreateP256KeyMaterial();
         using PrivateKeyMemory issuerPrivateKey = issuerKeys.PrivateKey;
@@ -1356,16 +1359,31 @@ internal sealed class Oid4VpFlowIntegrationTests
             holderPublicKey.AsReadOnlySpan(),
             TestSetup.Base64UrlEncoder);
 
+        var claims = new List<KeyValuePair<string, object>>
+        {
+            new(EudiPid.SdJwt.GivenName, givenName),
+            new(EudiPid.SdJwt.FamilyName, familyName)
+        };
+
+        if(status is not null)
+        {
+            //IETF Token Status List section 6: a non-disclosable status claim in the issuer payload.
+            claims.Add(new("status", new Dictionary<string, object>
+            {
+                ["status_list"] = new Dictionary<string, object>
+                {
+                    ["idx"] = status.Value.Index,
+                    ["uri"] = status.Value.Uri
+                }
+            }));
+        }
+
         JwtPayload payload = JwtPayload.ForSdJwtVcIssuance(
             issuer: IssuerId,
             verifiableCredentialType: EudiPid.SdJwtVct,
             issuedAt: TimeProvider.GetUtcNow(),
             holderConfirmation: holderJwk,
-            claims:
-            [
-                new(EudiPid.SdJwt.GivenName, givenName),
-                new(EudiPid.SdJwt.FamilyName, familyName)
-            ]);
+            claims: claims);
 
         var disclosablePaths = new HashSet<CredentialPath>
         {
@@ -1386,6 +1404,73 @@ internal sealed class Oid4VpFlowIntegrationTests
         string serializedSdJwt = SdJwtSerializer.SerializeToken(issuedToken, TestSetup.Base64UrlEncoder);
 
         return (serializedSdJwt, holderKeys.PrivateKey, issuerKeys.PublicKey);
+    }
+
+
+    //A genuinely issued SD-JWT VC that carries an IETF Token Status List reference is verified
+    //through the production path: the verifier surfaces the status_list reference, and the
+    //verifier-agnostic revocation gate reads it valid, then revoked once the credential's bit is
+    //flipped. This is the credential-verification flow any verifier runs — RP server, peer wallet,
+    //or agent — independent of the JAR/JWE presentation transport the other flow tests exercise.
+    [TestMethod]
+    public async Task SdJwtVcStatusReferenceSurfacesAndDrivesRevocationGate()
+    {
+        const string statusListUri = "https://issuer.example/statuslists/1";
+        const int credentialIndex = 42;
+        DateTimeOffset now = TimeProvider.GetUtcNow();
+
+        (string serializedSdJwt, PrivateKeyMemory holderPrivateKey, PublicKeyMemory issuerPublicKey) =
+            await IssuePidCredentialWithClaimsAsync(
+                "Alice", "Smith", TestContext.CancellationToken,
+                status: new StatusListReference(credentialIndex, statusListUri)).ConfigureAwait(false);
+
+        using(holderPrivateKey)
+        using(issuerPublicKey)
+        {
+            PublicKeyMemory? IssuerLookup(string iss) =>
+                string.Equals(iss, IssuerId, StringComparison.Ordinal) ? issuerPublicKey : null;
+
+            VpTokenParsed parsed = await SdJwtVpTokenVerification.VerifyAsync(
+                serializedSdJwt,
+                "pid",
+                static s => SdJwtSerializer.ParseToken(
+                    s, TestSetup.Base64UrlDecoder, SensitiveMemoryPool<byte>.Shared, TestSalts.TestSaltTag),
+                static t => SdJwtSerializer.GetSdJwtForHashing(t, TestSetup.Base64UrlEncoder),
+                IssuerLookup,
+                MicrosoftEntropyFunctions.ComputeDigestAsync,
+                TestSetup.Base64UrlDecoder,
+                TestSetup.Base64UrlEncoder,
+                Pool,
+                saltReuseSeam: null,
+                TestContext.CancellationToken).ConfigureAwait(false);
+
+            Assert.IsTrue(parsed.CredentialSignatureValid, "The issued credential must verify.");
+            Assert.IsNotNull(parsed.CredentialStatus, "The verifier must surface the credential's status_list reference.");
+            Assert.AreEqual(credentialIndex, parsed.CredentialStatus.Value.Index);
+            Assert.AreEqual(statusListUri, parsed.CredentialStatus.Value.Uri);
+
+            //The resolver stands in for whatever fetched and verified the status list (an HTTP fetch,
+            //or an Orleans status-list grain); here the verified token is built directly.
+            using StatusListType statusList = StatusListType.Create(
+                64, StatusListBitSize.OneBit, Pool, BitOrder.LeastSignificantFirst);
+
+            CredentialStatusOutcome beforeRevocation = await CredentialStatusGate.CheckAsync(
+                parsed.CredentialStatus.Value,
+                (uri, ct) => ValueTask.FromResult(new StatusListToken(statusListUri, now, statusList)),
+                now,
+                TestContext.CancellationToken).ConfigureAwait(false);
+            Assert.IsTrue(beforeRevocation.IsValid, "An unset status bit must read as valid.");
+
+            statusList[credentialIndex] = StatusTypes.Invalid;
+
+            CredentialStatusOutcome afterRevocation = await CredentialStatusGate.CheckAsync(
+                parsed.CredentialStatus.Value,
+                (uri, ct) => ValueTask.FromResult(new StatusListToken(statusListUri, now, statusList)),
+                now,
+                TestContext.CancellationToken).ConfigureAwait(false);
+            Assert.IsFalse(afterRevocation.IsValid, "After flipping the credential's bit the status must read as revoked.");
+            Assert.AreEqual(StatusTypes.Invalid, afterRevocation.Status);
+        }
     }
 
 

--- a/test/Verifiable.Tests/OAuth/TokenIntrospectionServerTests.cs
+++ b/test/Verifiable.Tests/OAuth/TokenIntrospectionServerTests.cs
@@ -1,0 +1,285 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
+using Verifiable.Core;
+using Verifiable.OAuth;
+using Verifiable.OAuth.Introspection;
+using Verifiable.OAuth.Server;
+using Verifiable.Tests.TestInfrastructure;
+
+namespace Verifiable.Tests.OAuth;
+
+/// <summary>
+/// Server-side RFC 7662 token introspection, driven through the real dispatch pipeline.
+/// The library owns the wire (client authentication, the §2.2 JSON shape, the rule that an
+/// inactive token discloses nothing further, the fail-closed candidate gate); the
+/// application owns the token store behind <see cref="IntrospectTokenDelegate"/>.
+/// </summary>
+[TestClass]
+internal sealed class TokenIntrospectionServerTests
+{
+    /// <summary>The MSTest-supplied per-test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>A fixed clock so issued artefacts are reproducible.</summary>
+    private FakeTimeProvider TimeProvider { get; } = new(
+        new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero));
+
+    /// <summary>The protected-resource client identifier registered for the introspection tests.</summary>
+    private const string ClientId = "https://introspection.client.test";
+
+    /// <summary>The base URI the registered client is reachable at.</summary>
+    private static readonly Uri ClientBaseUri = new("https://introspection.client.test");
+
+    /// <summary>The single capability the introspection endpoint requires.</summary>
+    private static readonly ImmutableHashSet<CapabilityIdentifier> IntrospectionCapabilities =
+        ImmutableHashSet.Create(WellKnownCapabilityIdentifiers.OAuthTokenIntrospection);
+
+
+    /// <summary>
+    /// A wired introspection endpoint authenticates the caller, relays the token and hint to
+    /// the application seam, and answers RFC 7662 §2.2 with the token's metadata as
+    /// <c>application/json</c> — including service-specific extension members (here the
+    /// RFC 9470 <c>acr</c>/<c>auth_time</c> a step-up deployment records).
+    /// </summary>
+    [TestMethod]
+    public async Task IntrospectionEndpointAuthenticatesCallerAndReturnsActiveTokenMetadata()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterClient(
+            ClientId, ClientBaseUri, IntrospectionCapabilities);
+
+        DateTimeOffset issuedAt = new(2026, 6, 1, 11, 0, 0, TimeSpan.Zero);
+        DateTimeOffset expiresAt = new(2026, 6, 1, 13, 0, 0, TimeSpan.Zero);
+
+        List<(string Token, string? Hint, ClientRecord Client)> introspected = [];
+        host.Server.Integration.ValidateClientCredentialsAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(true);
+        host.Server.Integration.IntrospectTokenAsync = (token, hint, registration, _, _) =>
+        {
+            introspected.Add((token, hint, registration));
+
+            return ValueTask.FromResult(new TokenIntrospectionResult
+            {
+                IsActive = true,
+                Scope = "read write",
+                ClientId = "https://some.other.client",
+                Username = "jdoe",
+                TokenType = "Bearer",
+                Subject = "Z5O3upPC88QrAjx00dis",
+                Audience = ["https://protected.example.net/resource"],
+                Issuer = "https://introspection.client.test",
+                JwtId = "token-jti-1",
+                IssuedAt = issuedAt,
+                ExpiresAt = expiresAt,
+                AdditionalClaims = new Dictionary<string, object>
+                {
+                    ["acr"] = "urn:mace:incommon:iap:silver",
+                    ["auth_time"] = issuedAt.ToUnixTimeSeconds()
+                }
+            });
+        };
+
+        ServerHttpResponse response = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value,
+            WellKnownEndpointNames.AuthCodeIntrospect,
+            "POST",
+            new RequestFields
+            {
+                [OAuthRequestParameterNames.Token] = "access-token-to-inspect",
+                [OAuthRequestParameterNames.TokenTypeHint] = "access_token"
+            },
+            new ExchangeContext(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(200, response.StatusCode, response.Body);
+        Assert.AreEqual("application/json", response.ContentType);
+
+        Assert.HasCount(1, introspected, "The seam must be invoked exactly once.");
+        Assert.AreEqual("access-token-to-inspect", introspected[0].Token);
+        Assert.AreEqual("access_token", introspected[0].Hint);
+        Assert.AreEqual(material.Registration.ClientId, introspected[0].Client.ClientId);
+
+        using JsonDocument document = JsonDocument.Parse(response.Body);
+        JsonElement root = document.RootElement;
+
+        Assert.IsTrue(root.GetProperty("active").GetBoolean(), "RFC 7662 §2.2 active must be true.");
+        Assert.AreEqual("read write", root.GetProperty("scope").GetString());
+        Assert.AreEqual("https://some.other.client", root.GetProperty("client_id").GetString());
+        Assert.AreEqual("jdoe", root.GetProperty("username").GetString());
+        Assert.AreEqual("Bearer", root.GetProperty("token_type").GetString());
+        Assert.AreEqual("Z5O3upPC88QrAjx00dis", root.GetProperty("sub").GetString());
+        Assert.AreEqual("https://introspection.client.test", root.GetProperty("iss").GetString());
+        Assert.AreEqual("token-jti-1", root.GetProperty("jti").GetString());
+        Assert.AreEqual(issuedAt.ToUnixTimeSeconds(), root.GetProperty("iat").GetInt64());
+        Assert.AreEqual(expiresAt.ToUnixTimeSeconds(), root.GetProperty("exp").GetInt64());
+
+        //A single audience is written as a JSON string (RFC 7662 §2.2 / RFC 7519 aud).
+        Assert.AreEqual(JsonValueKind.String, root.GetProperty("aud").ValueKind);
+        Assert.AreEqual("https://protected.example.net/resource", root.GetProperty("aud").GetString());
+
+        //RFC 7662 §2.2 extension members appear as top-level members.
+        Assert.AreEqual("urn:mace:incommon:iap:silver", root.GetProperty("acr").GetString());
+        Assert.AreEqual(issuedAt.ToUnixTimeSeconds(), root.GetProperty("auth_time").GetInt64());
+    }
+
+
+    /// <summary>
+    /// Multiple audiences are written as a JSON array, a single audience as a string — both
+    /// valid <c>aud</c> shapes per RFC 7519, which RFC 7662 §2.2 inherits.
+    /// </summary>
+    [TestMethod]
+    public async Task IntrospectionEndpointWritesMultipleAudiencesAsArray()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterClient(
+            ClientId, ClientBaseUri, IntrospectionCapabilities);
+
+        host.Server.Integration.ValidateClientCredentialsAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(true);
+        host.Server.Integration.IntrospectTokenAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(new TokenIntrospectionResult
+            {
+                IsActive = true,
+                Audience = ["https://resource.one/api", "https://resource.two/api"]
+            });
+
+        ServerHttpResponse response = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value,
+            WellKnownEndpointNames.AuthCodeIntrospect,
+            "POST",
+            new RequestFields { [OAuthRequestParameterNames.Token] = "multi-aud-token" },
+            new ExchangeContext(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(200, response.StatusCode, response.Body);
+
+        using JsonDocument document = JsonDocument.Parse(response.Body);
+        JsonElement aud = document.RootElement.GetProperty("aud");
+
+        Assert.AreEqual(JsonValueKind.Array, aud.ValueKind);
+        Assert.AreEqual(2, aud.GetArrayLength());
+        Assert.AreEqual("https://resource.one/api", aud[0].GetString());
+        Assert.AreEqual("https://resource.two/api", aud[1].GetString());
+    }
+
+
+    /// <summary>
+    /// RFC 7662 §2.2/§2.3: a well-formed, authorized query for an inactive token is not an
+    /// error — it answers 200 with <c>{"active":false}</c>. The library enforces the
+    /// non-disclosure rule itself: even when the application's result carries metadata, an
+    /// inactive result emits the <c>active</c> member and nothing else, so a probing resource
+    /// learns nothing about why the token is inactive.
+    /// </summary>
+    [TestMethod]
+    public async Task IntrospectionEndpointInactiveTokenDisclosesNothingFurther()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterClient(
+            ClientId, ClientBaseUri, IntrospectionCapabilities);
+
+        host.Server.Integration.ValidateClientCredentialsAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(true);
+
+        //An application that (incorrectly) attaches metadata to an inactive result must not
+        //be able to leak it: the library writes only active when IsActive is false.
+        host.Server.Integration.IntrospectTokenAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(new TokenIntrospectionResult
+            {
+                IsActive = false,
+                Subject = "should-not-appear",
+                Scope = "should-not-appear"
+            });
+
+        ServerHttpResponse response = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value,
+            WellKnownEndpointNames.AuthCodeIntrospect,
+            "POST",
+            new RequestFields { [OAuthRequestParameterNames.Token] = "revoked-or-unknown" },
+            new ExchangeContext(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(200, response.StatusCode, response.Body);
+        Assert.AreEqual("application/json", response.ContentType);
+
+        using JsonDocument document = JsonDocument.Parse(response.Body);
+        JsonElement root = document.RootElement;
+
+        Assert.IsFalse(root.GetProperty("active").GetBoolean());
+
+        int memberCount = 0;
+        foreach(JsonProperty _ in root.EnumerateObject())
+        {
+            memberCount++;
+        }
+
+        Assert.AreEqual(1, memberCount, "An inactive response must carry only the active member (RFC 7662 §2.2).");
+    }
+
+
+    /// <summary>
+    /// When client authentication fails the endpoint returns 401 <c>invalid_client</c> and
+    /// never reaches the introspection seam — token state is not leaked to an unauthenticated
+    /// caller (RFC 7662 §2.3).
+    /// </summary>
+    [TestMethod]
+    public async Task IntrospectionEndpointRejectsUnauthenticatedCallerWithoutTouchingTheStore()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterClient(
+            ClientId, ClientBaseUri, IntrospectionCapabilities);
+
+        bool seamInvoked = false;
+        host.Server.Integration.ValidateClientCredentialsAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(false);
+        host.Server.Integration.IntrospectTokenAsync = (_, _, _, _, _) =>
+        {
+            seamInvoked = true;
+
+            return ValueTask.FromResult(TokenIntrospectionResult.Inactive);
+        };
+
+        ServerHttpResponse response = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value,
+            WellKnownEndpointNames.AuthCodeIntrospect,
+            "POST",
+            new RequestFields { [OAuthRequestParameterNames.Token] = "some-token" },
+            new ExchangeContext(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(401, response.StatusCode, response.Body);
+        Assert.Contains(OAuthErrors.InvalidClient, response.Body, StringComparison.Ordinal);
+        Assert.IsFalse(seamInvoked, "A failed authentication must not introspect anything.");
+    }
+
+
+    /// <summary>
+    /// Fail-closed: declaring the introspection capability without wiring the introspection
+    /// seam leaves the endpoint absent from the chain, so a request to it returns 404 rather
+    /// than silently answering for a store it cannot read.
+    /// </summary>
+    [TestMethod]
+    public async Task IntrospectionEndpointAbsentWhenSeamUnwired()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterClient(
+            ClientId, ClientBaseUri, IntrospectionCapabilities);
+
+        //Client authentication is wired but the introspection seam is not — the candidate
+        //gate requires both, so the endpoint must not materialize.
+        host.Server.Integration.ValidateClientCredentialsAsync = static (_, _, _, _, _) =>
+            ValueTask.FromResult(true);
+
+        ServerHttpResponse response = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value,
+            WellKnownEndpointNames.AuthCodeIntrospect,
+            "POST",
+            new RequestFields { [OAuthRequestParameterNames.Token] = "some-token" },
+            new ExchangeContext(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(404, response.StatusCode,
+            "An unwired introspection seam must leave the endpoint absent (fail-closed).");
+    }
+}

--- a/test/Verifiable.Tests/StatusList/CredentialStatusGateTests.cs
+++ b/test/Verifiable.Tests/StatusList/CredentialStatusGateTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Buffers;
+using System.Threading.Tasks;
+using Verifiable.Core.StatusList;
+using Verifiable.Cryptography;
+
+using StatusListType = Verifiable.Core.StatusList.StatusList;
+
+namespace Verifiable.Tests.StatusList;
+
+/// <summary>
+/// Tests for <see cref="CredentialStatusGate"/>, the verifier-agnostic revocation gate. These
+/// exercise it as a bare static call — no OID4VP executor, no server pipeline — which is exactly
+/// how a peer wallet or an agent acting as the verifier would invoke it. The caller supplies the
+/// already-verified Status List Token through the resolver; here it is built directly, standing in
+/// for whatever fetched and verified it (an HTTP + JWS-verify, or an Orleans status-list grain).
+/// </summary>
+[TestClass]
+internal sealed class CredentialStatusGateTests
+{
+    private const string ListUri = "https://issuer.example/statuslists/1";
+    private const int CredentialIndex = 42;
+    private static readonly DateTimeOffset Now = new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static MemoryPool<byte> Pool => SensitiveMemoryPool<byte>.Shared;
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private static ResolveVerifiedStatusListTokenDelegate ResolverFor(StatusListToken token) =>
+        (uri, ct) => ValueTask.FromResult(token);
+
+
+    [TestMethod]
+    public async Task UnsetEntryReadsAsValid()
+    {
+        using var list = StatusListType.Create(64, StatusListBitSize.OneBit, Pool, BitOrder.LeastSignificantFirst);
+        var token = new StatusListToken(ListUri, Now, list);
+
+        CredentialStatusOutcome outcome = await CredentialStatusGate.CheckAsync(
+            new StatusListReference(CredentialIndex, ListUri), ResolverFor(token), Now, TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.IsTrue(outcome.IsValid);
+        Assert.AreEqual(StatusTypes.Valid, outcome.Status);
+    }
+
+
+    [TestMethod]
+    public async Task RevokedEntryReadsAsInvalid()
+    {
+        using var list = StatusListType.Create(64, StatusListBitSize.OneBit, Pool, BitOrder.LeastSignificantFirst);
+        list[CredentialIndex] = StatusTypes.Invalid;
+        var token = new StatusListToken(ListUri, Now, list);
+
+        CredentialStatusOutcome outcome = await CredentialStatusGate.CheckAsync(
+            new StatusListReference(CredentialIndex, ListUri), ResolverFor(token), Now, TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.IsFalse(outcome.IsValid);
+        Assert.AreEqual(StatusTypes.Invalid, outcome.Status);
+    }
+
+
+    [TestMethod]
+    public async Task SuspendedEntryReadsAsNotValid()
+    {
+        using var list = StatusListType.Create(64, StatusListBitSize.TwoBits, Pool, BitOrder.LeastSignificantFirst);
+        list[CredentialIndex] = StatusTypes.Suspended;
+        var token = new StatusListToken(ListUri, Now, list);
+
+        CredentialStatusOutcome outcome = await CredentialStatusGate.CheckAsync(
+            new StatusListReference(CredentialIndex, ListUri), ResolverFor(token), Now, TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.IsFalse(outcome.IsValid);
+        Assert.AreEqual(StatusTypes.Suspended, outcome.Status);
+    }
+
+
+    [TestMethod]
+    public async Task TokenWhoseSubjectDoesNotMatchTheReferenceFailsClosed()
+    {
+        using var list = StatusListType.Create(64, StatusListBitSize.OneBit, Pool, BitOrder.LeastSignificantFirst);
+        var tokenForAnotherList = new StatusListToken("https://issuer.example/statuslists/OTHER", Now, list);
+
+        StatusListValidationException? caught = null;
+        try
+        {
+            await CredentialStatusGate.CheckAsync(
+                new StatusListReference(CredentialIndex, ListUri), ResolverFor(tokenForAnotherList), Now, TestContext.CancellationToken).ConfigureAwait(false);
+        }
+        catch(StatusListValidationException exception)
+        {
+            caught = exception;
+        }
+
+        Assert.IsNotNull(caught, "A status list token whose subject does not match the reference URI must not pass.");
+    }
+}


### PR DESCRIPTION
- Pure CredentialStatusGate + status reference surfaced on VpTokenParsed (IETF Token Status List).
- RFC 7662 introspection endpoint (§2.2 JSON, inactive discloses nothing, stateless fail-closed gate).