### PR TITLE
Enforce the JWS crit header per RFC 7515 4.1.11

### DIFF
--- a/src/Verifiable.DidComm/DidCommSignedExtensions.cs
+++ b/src/Verifiable.DidComm/DidCommSignedExtensions.cs
@@ -326,6 +326,14 @@ public static class DidCommSignedExtensions
                 return DidCommSignedVerificationResult.Failed(DidCommSignatureVerificationError.UnexpectedMediaType);
             }
 
+            //RFC 7515 §4.1.11: this consumer understands no JWS critical extensions, so a signed message
+            //whose protected header names any critical extension is unprocessable and MUST be rejected —
+            //the underlying Jws.VerifySignatureAsync verifies the signing input but does not police crit.
+            if(jwsSignature.ProtectedHeader.TryGetValue("crit", out _))
+            {
+                return DidCommSignedVerificationResult.Failed(DidCommSignatureVerificationError.UnsupportedCriticalHeader);
+            }
+
             //The signer kid rides in the per-signature unprotected header (DIDComm v2.1 Appendix C.2).
             if(jwsSignature.UnprotectedHeader is null
                 || !jwsSignature.UnprotectedHeader.TryGetValue(WellKnownJwkMemberNames.Kid, out object? kidValue)

--- a/src/Verifiable.DidComm/DidCommSignedVerificationResult.cs
+++ b/src/Verifiable.DidComm/DidCommSignedVerificationResult.cs
@@ -46,6 +46,12 @@ public enum DidCommSignatureVerificationError
     UnexpectedMediaType,
 
     /// <summary>
+    /// The signature's protected header carries a <c>crit</c> (critical) parameter. This consumer
+    /// understands no JWS critical extensions, so per RFC 7515 §4.1.11 the JWS is invalid and rejected.
+    /// </summary>
+    UnsupportedCriticalHeader,
+
+    /// <summary>
     /// The plaintext <c>from</c> does not match the signer's <c>kid</c> DID — the
     /// addressing-consistency MUST (DIDComm v2.1: "The from attribute in the plaintext message MUST
     /// match the signer's kid in a signed message.").

--- a/src/Verifiable.JCose/Jose.cs
+++ b/src/Verifiable.JCose/Jose.cs
@@ -636,6 +636,15 @@ public static class Jws
             return false;
         }
 
+        //RFC 7515 §4.1.11: a JWS whose protected header names an unrecognized critical extension (or
+        //otherwise violates the crit producer rules) is invalid. Decode the header and fail closed to
+        //false — like a malformed segment — rather than verifying a message we cannot fully process.
+        using DecodedSegment protectedHeader = TryDecodeSegment(base64UrlDecoder, parts[0], pool);
+        if(!protectedHeader.IsDecoded || !JoseCriticalHeaderValidation.IsSatisfied(protectedHeader.Memory.Span))
+        {
+            return false;
+        }
+
         using IMemoryOwner<byte> dataToVerifyOwner = RentSigningInput(
             parts[0], parts[1], pool, out int signingInputLength);
 
@@ -762,7 +771,11 @@ public static class Jws
         using IMemoryOwner<byte> dataToVerifyOwner = RentSigningInput(
             parts[0], parts[1], pool, out int signingInputLength);
 
-        bool isValid = await verificationDelegate(
+        //RFC 7515 §4.1.11: a JWS naming an unrecognized critical extension is invalid; the decoded
+        //header/payload are still returned so the caller can inspect them, but with isValid false.
+        bool critSatisfied = JoseCriticalHeaderValidation.IsSatisfied(headerOwner.Memory.Span);
+
+        bool isValid = critSatisfied && await verificationDelegate(
             dataToVerifyOwner.Memory[..signingInputLength],
             signatureOwner.Memory,
             publicKey.AsReadOnlyMemory(),
@@ -907,6 +920,12 @@ public static class Jws
         //A malformed segment the decoder rejects cannot verify; fail closed to false rather than letting
         //the decoder's exception escape on untrusted input.
         if(!headerSegment.IsDecoded || !payloadSegment.IsDecoded || !signatureSegment.IsDecoded)
+        {
+            return false;
+        }
+
+        //RFC 7515 §4.1.11: fail closed to false on an unrecognized critical extension.
+        if(!JoseCriticalHeaderValidation.IsSatisfied(headerSegment.Memory.Span))
         {
             return false;
         }

--- a/src/Verifiable.JCose/JoseCriticalHeaderValidation.cs
+++ b/src/Verifiable.JCose/JoseCriticalHeaderValidation.cs
@@ -1,0 +1,188 @@
+using System.Collections.Frozen;
+
+namespace Verifiable.JCose;
+
+/// <summary>
+/// The shared <c>crit</c> (critical header) processing for JOSE protected headers, applied identically to
+/// JWS (<see href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1.11">RFC 7515 §4.1.11</see>) and JWE
+/// (<see href="https://www.rfc-editor.org/rfc/rfc7516#section-4.1.13">RFC 7516 §4.1.13</see>). One
+/// source of truth so the JWS verify path and the JWE parse path cannot drift apart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// RFC 7515 §4.1.11: a producer MUST NOT use the empty list, MUST NOT list Header Parameter names
+/// defined by the JWS/JWE/JWA specifications, and every name MUST occur as a Header Parameter in the
+/// JOSE Header. RFC 7516 §5.2 step 5: a recipient MUST reject a message naming a critical extension it
+/// does not understand. This validator enforces all of those; the caller declares which extensions it
+/// understands (none, by default), so an unrecognized critical extension is rejected.
+/// </para>
+/// <para>
+/// The header is read through the library's own span reader (<see cref="JwkJsonReader"/>); there is no
+/// JSON-serialization dependency in this project.
+/// </para>
+/// </remarks>
+public static class JoseCriticalHeaderValidation
+{
+    //The header parameter names registered by RFC 7515 §4.1, RFC 7516 §4.1, and RFC 7518 §4.6.1
+    //(epk/apu/apv) plus draft-madden-jose-ecdh-1pu-04 §2.2.1 (skid). A producer MUST NOT list any of
+    //these in "crit" (RFC 7515 §4.1.11), and this implementation already understands them, so a "crit"
+    //entry naming any of them is rejected on both grounds — for JWS and JWE alike.
+    private static readonly HashSet<string> RegisteredHeaderParameterNames = new(StringComparer.Ordinal)
+    {
+        WellKnownJwkMemberNames.Alg,
+        WellKnownJoseHeaderNames.Enc,
+        "zip",
+        WellKnownJoseHeaderNames.Epk,
+        WellKnownJoseHeaderNames.Apu,
+        WellKnownJoseHeaderNames.Apv,
+        WellKnownJoseHeaderNames.Skid,
+        WellKnownJoseHeaderNames.Typ,
+        WellKnownJoseHeaderNames.Cty,
+        WellKnownJoseHeaderNames.Jwk,
+        WellKnownJwkMemberNames.Kid,
+        "jku",
+        WellKnownJwkMemberNames.X5u,
+        WellKnownJwkMemberNames.X5c,
+        WellKnownJwkMemberNames.X5t,
+        WellKnownJwkMemberNames.X5tHashS256,
+        "crit"
+    };
+
+    /// <summary>The shared empty set for the no-understood-extension case (avoids per-call allocation).</summary>
+    public static IReadOnlySet<string> NoUnderstoodExtensions { get; } = FrozenSet<string>.Empty;
+
+
+    /// <summary>
+    /// Validates <c>crit</c> over a decoded protected header, throwing on any violation. Understands no
+    /// <c>crit</c> extension (any critical entry is rejected). Used by the JWE parse path.
+    /// </summary>
+    /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
+    /// <exception cref="FormatException">Thrown when <c>crit</c> is malformed, empty, lists a registered parameter, lists a name not present in the header, or names an unsupported extension.</exception>
+    public static void Validate(ReadOnlySpan<byte> headerJson) => Validate(headerJson, NoUnderstoodExtensions);
+
+
+    /// <summary>
+    /// Validates <c>crit</c> over a decoded protected header, throwing on any violation, accepting a set
+    /// of <c>crit</c> extensions the caller understands.
+    /// </summary>
+    /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
+    /// <param name="understoodCriticalExtensions">The <c>crit</c> extension names the caller processes.</param>
+    /// <exception cref="FormatException">Thrown for the reasons in <see cref="Validate(ReadOnlySpan{byte})"/>, except that a critical entry the caller understands is accepted.</exception>
+    public static void Validate(ReadOnlySpan<byte> headerJson, IReadOnlySet<string> understoodCriticalExtensions)
+    {
+        if(!TryValidate(headerJson, understoodCriticalExtensions, out string? failureReason))
+        {
+            throw new FormatException(failureReason);
+        }
+    }
+
+
+    /// <summary>
+    /// Whether <c>crit</c> is satisfied over a decoded protected header, understanding no extension. Never
+    /// throws — the non-throwing form the JWS verify path uses to fail closed to <see langword="false"/>.
+    /// </summary>
+    /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
+    public static bool IsSatisfied(ReadOnlySpan<byte> headerJson) => IsSatisfied(headerJson, NoUnderstoodExtensions);
+
+
+    /// <summary>
+    /// Whether <c>crit</c> is satisfied over a decoded protected header, accepting a set of extensions the
+    /// caller understands. Never throws.
+    /// </summary>
+    /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
+    /// <param name="understoodCriticalExtensions">The <c>crit</c> extension names the caller processes.</param>
+    public static bool IsSatisfied(ReadOnlySpan<byte> headerJson, IReadOnlySet<string> understoodCriticalExtensions) =>
+        TryValidate(headerJson, understoodCriticalExtensions, out _);
+
+
+    //RFC 7515 §4.1.11 / RFC 7516 §4.1.13: the single crit rule set, expressed without throwing so both a
+    //throwing (JWE) and a fail-closed bool (JWS) caller can share it. Returns false with a reason on any
+    //violation: a present-but-non-array crit, the empty list, a registered name, a name absent from the
+    //header, or an extension the caller has not declared understood.
+    private static bool TryValidate(
+        ReadOnlySpan<byte> headerJson,
+        IReadOnlySet<string> understoodCriticalExtensions,
+        out string? failureReason)
+    {
+        ArgumentNullException.ThrowIfNull(understoodCriticalExtensions);
+
+        List<string>? critNames = JwkJsonReader.ExtractStringArrayProperty(headerJson, "crit"u8);
+        if(critNames is null)
+        {
+            //Absent "crit" is fine; a present "crit" that is not a string array is a malformed producer
+            //header per RFC 7515 §4.1.11 — distinguish it from absence so it is rejected rather than
+            //silently treated as "no crit".
+            if(JwkJsonReader.ContainsKey(headerJson, "crit"u8))
+            {
+                failureReason = "The 'crit' header parameter must be a JSON array of strings (RFC 7515 §4.1.11).";
+
+                return false;
+            }
+
+            failureReason = null;
+
+            return true;
+        }
+
+        if(critNames.Count == 0)
+        {
+            //RFC 7515 §4.1.11: "Producers MUST NOT use the empty list "[]" as the "crit" value."
+            failureReason = "The 'crit' header parameter MUST NOT be the empty list (RFC 7515 §4.1.11).";
+
+            return false;
+        }
+
+        for(int i = 0; i < critNames.Count; ++i)
+        {
+            string name = critNames[i];
+
+            if(RegisteredHeaderParameterNames.Contains(name))
+            {
+                //RFC 7515 §4.1.11: producers MUST NOT include names defined by the JWS/JWE/JWA
+                //specifications in "crit"; a caller cannot whitelist a registered name.
+                failureReason =
+                    $"The 'crit' header parameter lists the registered parameter '{name}', "
+                    + "which producers MUST NOT include (RFC 7515 §4.1.11).";
+
+                return false;
+            }
+
+            if(!HeaderContainsName(headerJson, name))
+            {
+                //RFC 7515 §4.1.11: names in "crit" MUST occur as Header Parameter names within the JOSE Header.
+                failureReason =
+                    $"The 'crit' header parameter lists '{name}', which does not occur as a "
+                    + "header parameter in the JOSE Header (RFC 7515 §4.1.11).";
+
+                return false;
+            }
+
+            if(!understoodCriticalExtensions.Contains(name))
+            {
+                //RFC 7515 §4.1.11 / RFC 7516 §5.2 step 5: a critical extension the recipient does not
+                //understand makes the message invalid.
+                failureReason =
+                    $"The 'crit' header parameter requires understanding extension '{name}', which "
+                    + "this consumer does not declare understood (RFC 7515 §4.1.11).";
+
+                return false;
+            }
+        }
+
+        failureReason = null;
+
+        return true;
+    }
+
+
+    //Whether the header JSON carries a top-level member named exactly "name". The name arrives as an
+    //already-decoded string from the "crit" array; encode it to UTF-8 once and scan for a top-level key.
+    private static bool HeaderContainsName(ReadOnlySpan<byte> headerJson, string name)
+    {
+        int byteCount = System.Text.Encoding.UTF8.GetByteCount(name);
+        Span<byte> nameBytes = byteCount <= 128 ? stackalloc byte[byteCount] : new byte[byteCount];
+        System.Text.Encoding.UTF8.GetBytes(name, nameBytes);
+
+        return JwkJsonReader.ContainsKey(headerJson, nameBytes);
+    }
+}

--- a/src/Verifiable.JCose/JweHeaderProcessing.cs
+++ b/src/Verifiable.JCose/JweHeaderProcessing.cs
@@ -1,98 +1,61 @@
 namespace Verifiable.JCose;
 
 /// <summary>
-/// Shared JWE protected-header processing applied at every parse boundary: <c>crit</c>
-/// validation per RFC 7515 §4.1.11 / RFC 7516 §4.1.13, and the rejected-by-design algorithm
-/// guards (<c>RSA1_5</c> per RFC 8725 §3.2, <c>zip</c> per RFC 8725 §3.6 / RFC 7516 §4.1.3).
+/// JWE protected-header processing applied at every parse boundary: the duplicate-name and
+/// rejected-by-design algorithm guards (<c>RSA1_5</c> per RFC 8725 §3.2, <c>zip</c> per RFC 8725 §3.6 /
+/// RFC 7516 §4.1.3), and <c>crit</c> validation delegated to <see cref="JoseCriticalHeaderValidation"/>
+/// (the shared RFC 7515 §4.1.11 / RFC 7516 §4.1.13 rule set used by both JWE and JWS).
 /// </summary>
 /// <remarks>
 /// <para>
-/// RFC 7516 §5.2 step 5 requires a consumer to verify that it understands and can process all
-/// fields it is required to support, including those named by the <c>crit</c> Header Parameter.
-/// This library understands no JWE header extensions beyond the registered parameters, so any
-/// <c>crit</c> entry naming an unregistered extension is unsupported and the message MUST be
-/// rejected unless the caller declares that extension understood; an entry naming a registered
-/// parameter violates the RFC 7515 §4.1.11 producer rule and MUST always be rejected.
+/// RFC 7516 §5.2 step 5 requires a consumer to verify that it understands and can process all fields it
+/// is required to support, including those named by the <c>crit</c> Header Parameter. This library
+/// understands no JWE header extensions beyond the registered parameters, so any <c>crit</c> entry naming
+/// an unregistered extension is unsupported and the message MUST be rejected unless the caller declares
+/// that extension understood; an entry naming a registered parameter violates the RFC 7515 §4.1.11
+/// producer rule and MUST always be rejected.
 /// </para>
 /// <para>
-/// The validators read the already-decoded protected header JSON through the library's own
-/// span reader (<see cref="JwkJsonReader"/>); there is no JSON-serialization dependency in this
-/// project, so <c>crit</c> is read with <see cref="JwkJsonReader.ExtractStringArrayProperty"/>
-/// rather than a deserializer.
+/// The header is read through the library's own span reader (<see cref="JwkJsonReader"/>); there is no
+/// JSON-serialization dependency in this project.
 /// </para>
 /// </remarks>
 public static class JweHeaderProcessing
 {
-    //The header parameter names registered by RFC 7515 §4.1, RFC 7516 §4.1, and RFC 7518 §4.6.1
-    //(epk/apu/apv) plus draft-madden-jose-ecdh-1pu-04 §2.2.1 (skid). These are the names a
-    //producer MUST NOT list in "crit" (RFC 7515 §4.1.11) and that this implementation already
-    //understands, so a "crit" entry naming any of them is rejected on both grounds.
-    private static readonly HashSet<string> RegisteredHeaderParameterNames = new(StringComparer.Ordinal)
-    {
-        WellKnownJwkMemberNames.Alg,
-        WellKnownJoseHeaderNames.Enc,
-        "zip",
-        WellKnownJoseHeaderNames.Epk,
-        WellKnownJoseHeaderNames.Apu,
-        WellKnownJoseHeaderNames.Apv,
-        WellKnownJoseHeaderNames.Skid,
-        WellKnownJoseHeaderNames.Typ,
-        WellKnownJoseHeaderNames.Cty,
-        WellKnownJoseHeaderNames.Jwk,
-        WellKnownJwkMemberNames.Kid,
-        "jku",
-        WellKnownJwkMemberNames.X5u,
-        WellKnownJwkMemberNames.X5c,
-        WellKnownJwkMemberNames.X5t,
-        WellKnownJwkMemberNames.X5tHashS256,
-        "crit"
-    };
-
-
     /// <summary>
-    /// Validates the protected-header <c>crit</c> parameter and the rejected-by-design
-    /// algorithm guards over the decoded protected header JSON.
+    /// Validates the protected-header <c>crit</c> parameter and the rejected-by-design algorithm guards
+    /// over the decoded protected header JSON, understanding no <c>crit</c> extension.
     /// </summary>
     /// <remarks>
-    /// Call after the <c>alg</c>/<c>enc</c> have been extracted but before any cryptographic
-    /// work, so an unprocessable message is rejected before key agreement runs (RFC 7516 §5.2
-    /// step 5 precedes steps 6–16). This overload understands no <c>crit</c> extension; any
-    /// critical entry naming an unregistered parameter is rejected. Use
-    /// <see cref="Validate(ReadOnlySpan{byte}, string, IReadOnlySet{string})"/> to declare a
-    /// set of extensions the caller processes.
+    /// Call after the <c>alg</c>/<c>enc</c> have been extracted but before any cryptographic work, so an
+    /// unprocessable message is rejected before key agreement runs (RFC 7516 §5.2 step 5 precedes steps
+    /// 6–16). Use <see cref="Validate(ReadOnlySpan{byte}, string, IReadOnlySet{string})"/> to declare a
+    /// set of <c>crit</c> extensions the caller processes.
     /// </remarks>
     /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
     /// <param name="algorithm">The already-extracted <c>alg</c> value.</param>
     /// <exception cref="FormatException">
-    /// Thrown when <c>crit</c> is malformed, empty, lists a registered parameter, lists a
-    /// parameter not present in the header, or names an extension this implementation does not
-    /// understand; when <c>RSA1_5</c> is the key management algorithm; or when a <c>zip</c>
-    /// parameter is present.
+    /// Thrown when the header has duplicate parameter names; when <c>crit</c> is malformed, empty, lists a
+    /// registered parameter, lists a parameter not present in the header, or names an extension this
+    /// implementation does not understand; when <c>RSA1_5</c> is the key management algorithm; or when a
+    /// <c>zip</c> parameter is present.
     /// </exception>
     public static void Validate(ReadOnlySpan<byte> headerJson, string algorithm) =>
-        Validate(headerJson, algorithm, understoodCriticalExtensions: EmptyExtensions);
+        Validate(headerJson, algorithm, JoseCriticalHeaderValidation.NoUnderstoodExtensions);
 
 
     /// <summary>
-    /// Validates the protected-header <c>crit</c> parameter and the rejected-by-design
-    /// algorithm guards, accepting a set of <c>crit</c> extensions the caller understands.
+    /// Validates the protected-header <c>crit</c> parameter and the rejected-by-design algorithm guards,
+    /// accepting a set of <c>crit</c> extensions the caller understands.
     /// </summary>
-    /// <remarks>
-    /// A critical entry that names one of <paramref name="understoodCriticalExtensions"/> is
-    /// accepted (RFC 7515 §4.1.11: "If any of the listed extension Header Parameters are not
-    /// understood and supported by the recipient, then the JWS is invalid."). An entry naming a
-    /// registered parameter is always rejected — a producer MUST NOT place registered names in
-    /// <c>crit</c>, so the caller cannot whitelist them.
-    /// </remarks>
     /// <param name="headerJson">The decoded UTF-8 protected header JSON bytes.</param>
     /// <param name="algorithm">The already-extracted <c>alg</c> value.</param>
     /// <param name="understoodCriticalExtensions">
     /// The set of <c>crit</c> extension names the caller declares it understands and processes.
     /// </param>
     /// <exception cref="FormatException">
-    /// Thrown for the same reasons as <see cref="Validate(ReadOnlySpan{byte}, string)"/>, except
-    /// that a critical entry present in <paramref name="understoodCriticalExtensions"/> is
-    /// accepted.
+    /// Thrown for the same reasons as <see cref="Validate(ReadOnlySpan{byte}, string)"/>, except that a
+    /// critical entry present in <paramref name="understoodCriticalExtensions"/> is accepted.
     /// </exception>
     public static void Validate(
         ReadOnlySpan<byte> headerJson,
@@ -104,12 +67,10 @@ public static class JweHeaderProcessing
 
         if(JwkJsonReader.HasDuplicateTopLevelKeys(headerJson))
         {
-            //RFC 7516 §4 ("The Header Parameter names within the JOSE Header MUST be unique") and
-            //§5.2 step 4 ("verify that the resulting JOSE Header does not contain duplicate Header
-            //Parameter names"). The library reads each parameter by first occurrence; without this
-            //gate a header repeating "alg" would be processed with the first value while a
-            //last-value JSON parser elsewhere would disagree — the validate-one/act-on-another
-            //divergence this check closes.
+            //RFC 7516 §4 ("The Header Parameter names within the JOSE Header MUST be unique") and §5.2
+            //step 4. The library reads each parameter by first occurrence; without this gate a header
+            //repeating "alg" would be processed with the first value while a last-value JSON parser
+            //elsewhere would disagree — the validate-one/act-on-another divergence this check closes.
             throw new FormatException(
                 "JWE protected header contains duplicate Header Parameter names, which MUST be "
                 + "unique (RFC 7516 §4 / §5.2 step 4).");
@@ -119,16 +80,15 @@ public static class JweHeaderProcessing
 
         if(JwkJsonReader.ContainsKey(headerJson, "zip"u8))
         {
-            //RFC 8725 §3.6: compression of data SHOULD NOT be done before encryption because
-            //compressed data reveals information about the plaintext (a length oracle). This
-            //library rejects any JWE carrying "zip" rather than expanding the plaintext.
+            //RFC 8725 §3.6: compression before encryption reveals information about the plaintext (a
+            //length oracle). This library rejects any JWE carrying "zip" rather than expanding it.
             throw new FormatException(
                 "JWE tokens with a 'zip' compression parameter are rejected: compressing the "
                 + "plaintext before encryption leaks plaintext length and enables compression "
                 + "oracles (RFC 8725 §3.6).");
         }
 
-        ValidateCrit(headerJson, understoodCriticalExtensions);
+        JoseCriticalHeaderValidation.Validate(headerJson, understoodCriticalExtensions);
     }
 
 
@@ -143,100 +103,13 @@ public static class JweHeaderProcessing
 
         if(WellKnownJweAlgorithms.IsRsa15(algorithm))
         {
-            //RFC 8725 §3.2: "Avoid all RSA-PKCS1 v1.5 encryption algorithms, preferring
-            //RSAES-OAEP." RSAES-PKCS1-v1_5 (RSA1_5) is vulnerable to Bleichenbacher-style
-            //adaptive chosen-ciphertext (million-message) attacks, so this library refuses it.
+            //RFC 8725 §3.2: "Avoid all RSA-PKCS1 v1.5 encryption algorithms, preferring RSAES-OAEP."
+            //RSAES-PKCS1-v1_5 (RSA1_5) is vulnerable to Bleichenbacher-style adaptive chosen-ciphertext
+            //(million-message) attacks, so this library refuses it.
             throw new FormatException(
                 "The 'RSA1_5' (RSAES-PKCS1-v1_5) key management algorithm is rejected: it is "
                 + "vulnerable to Bleichenbacher adaptive chosen-ciphertext attacks and MUST be "
                 + "avoided in favour of RSAES-OAEP (RFC 8725 §3.2).");
         }
     }
-
-
-    //RFC 7515 §4.1.11 / RFC 7516 §4.1.13: process "crit" by rejecting any message whose crit
-    //lists a parameter the implementation does not understand, and any message whose crit
-    //violates the producer rules (empty list, registered names, names absent from the header).
-    private static void ValidateCrit(
-        ReadOnlySpan<byte> headerJson,
-        IReadOnlySet<string> understoodCriticalExtensions)
-    {
-        List<string>? critNames = JwkJsonReader.ExtractStringArrayProperty(headerJson, "crit"u8);
-        if(critNames is null)
-        {
-            //Absent "crit", or a "crit" whose value is not a string-only JSON array. A present
-            //"crit" that is not a string array is a malformed producer header per RFC 7515
-            //§4.1.11; distinguish it from absence so a malformed value is rejected rather than
-            //silently treated as "no crit".
-            if(JwkJsonReader.ContainsKey(headerJson, "crit"u8))
-            {
-                throw new FormatException(
-                    "The 'crit' header parameter must be a JSON array of strings (RFC 7515 §4.1.11).");
-            }
-
-            return;
-        }
-
-        if(critNames.Count == 0)
-        {
-            //RFC 7515 §4.1.11: "Producers MUST NOT use the empty list "[]" as the "crit" value."
-            throw new FormatException(
-                "The 'crit' header parameter MUST NOT be the empty list (RFC 7515 §4.1.11).");
-        }
-
-        for(int i = 0; i < critNames.Count; ++i)
-        {
-            string name = critNames[i];
-
-            if(RegisteredHeaderParameterNames.Contains(name))
-            {
-                //RFC 7515 §4.1.11: producers MUST NOT include names defined by the JWS/JWE/JWA
-                //specifications in "crit"; recipients MAY consider such a message invalid. This
-                //library does, and a caller cannot whitelist a registered name.
-                throw new FormatException(
-                    $"The 'crit' header parameter lists the registered parameter '{name}', "
-                    + "which producers MUST NOT include (RFC 7515 §4.1.11).");
-            }
-
-            if(!HeaderContainsName(headerJson, name))
-            {
-                //RFC 7515 §4.1.11: names in "crit" MUST occur as Header Parameter names within
-                //the JOSE Header.
-                throw new FormatException(
-                    $"The 'crit' header parameter lists '{name}', which does not occur as a "
-                    + "header parameter in the JOSE Header (RFC 7515 §4.1.11).");
-            }
-
-            if(!understoodCriticalExtensions.Contains(name))
-            {
-                //RFC 7516 §5.2 step 5: a critical extension the recipient does not understand
-                //makes the message invalid. The caller declares the extensions it processes; an
-                //undeclared critical name is rejected.
-                throw new FormatException(
-                    $"The 'crit' header parameter requires understanding extension '{name}', which "
-                    + "this consumer does not declare understood, so the JWE is rejected (RFC 7516 "
-                    + "§5.2 step 5, RFC 7515 §4.1.11).");
-            }
-        }
-    }
-
-
-    //Whether the header JSON carries a top-level member named exactly "name". The name arrives
-    //as an already-decoded string from the "crit" array; encode it to UTF-8 once and scan for a
-    //top-level key. A pooled scratch buffer is unnecessary here — crit names are short, bounded
-    //identifiers and the scan is a key-presence check, not a hot path.
-    private static bool HeaderContainsName(ReadOnlySpan<byte> headerJson, string name)
-    {
-        int byteCount = System.Text.Encoding.UTF8.GetByteCount(name);
-        Span<byte> nameBytes = byteCount <= 128 ? stackalloc byte[byteCount] : new byte[byteCount];
-        System.Text.Encoding.UTF8.GetBytes(name, nameBytes);
-
-        return JwkJsonReader.ContainsKey(headerJson, nameBytes);
-    }
-
-
-    //The shared empty set for the no-understood-extension overload. A frozen empty set avoids
-    //allocating a fresh HashSet on every parse-boundary call.
-    private static readonly IReadOnlySet<string> EmptyExtensions =
-        System.Collections.Frozen.FrozenSet<string>.Empty;
 }

--- a/test/Verifiable.Tests/Jose/JwsCriticalHeaderTests.cs
+++ b/test/Verifiable.Tests/Jose/JwsCriticalHeaderTests.cs
@@ -1,0 +1,86 @@
+using System.Buffers;
+using Verifiable.Cryptography;
+using Verifiable.JCose;
+using Verifiable.Json;
+using Verifiable.Microsoft;
+using Verifiable.Tests.TestDataProviders;
+using Verifiable.Tests.TestInfrastructure;
+
+namespace Verifiable.Tests.Jose;
+
+/// <summary>
+/// Tests that the JWS verify path enforces the <c>crit</c> (critical header) rule of
+/// <see href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1.11">RFC 7515 §4.1.11</see> via
+/// <see cref="JoseCriticalHeaderValidation"/>: a JWS whose protected header declares a critical
+/// extension the consumer does not understand MUST NOT verify, even when its signature is valid. The
+/// rule set itself is covered by the JWE header-processing tests (both paths share the validator); this
+/// proves the wiring on the JWS side that the consumer-feedback audit found missing.
+/// </summary>
+[TestClass]
+internal sealed class JwsCriticalHeaderTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    private static MemoryPool<byte> Pool => BaseMemoryPool.Shared;
+
+    /// <summary>Serialises a protected header to UTF-8 JSON bytes.</summary>
+    private static readonly JwtHeaderSerializer HeaderSerializer =
+        static header => JsonSerializerExtensions.SerializeToUtf8Bytes(
+            (Dictionary<string, object>)header, TestSetup.DefaultSerializationOptions);
+
+    /// <summary>Serialises a payload to UTF-8 JSON bytes.</summary>
+    private static readonly JwtPayloadSerializer PayloadSerializer =
+        static payload => JsonSerializerExtensions.SerializeToUtf8Bytes(
+            (Dictionary<string, object>)payload, TestSetup.DefaultSerializationOptions);
+
+
+    /// <summary>
+    /// A validly-signed JWS whose protected header names an unrecognized critical extension does not
+    /// verify (RFC 7515 §4.1.11); the otherwise-identical crit-free JWS does verify — so the rejection
+    /// is the <c>crit</c> rule, not the signature.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyRejectsUnrecognizedCriticalExtension()
+    {
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keyMaterial =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory publicKey = keyMaterial.PublicKey;
+        using PrivateKeyMemory privateKey = keyMaterial.PrivateKey;
+
+        string algorithm = CryptoFormatConversions.DefaultTagToJwaConverter(privateKey.Tag);
+        JwtPayload payload = new() { ["sub"] = "alice" };
+
+        //A JWS whose protected header declares a critical extension this consumer does not understand.
+        JwtHeader crittedHeader = JwtHeader.ForSigning(algorithm, WellKnownJwkValues.TypeJwt, "k1");
+        crittedHeader["crit"] = new[] { "urn:example:my-extension" };
+        crittedHeader["urn:example:my-extension"] = "present";
+        string crittedJws = await SignCompactAsync(crittedHeader, payload, privateKey).ConfigureAwait(false);
+
+        bool crittedVerifies = await Jws.VerifyAsync(
+            crittedJws, TestSetup.Base64UrlDecoder, Pool, publicKey,
+            MicrosoftCryptographicFunctions.VerifyP256Async, TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.IsFalse(crittedVerifies, "a JWS naming an unrecognized critical extension must not verify (RFC 7515 §4.1.11).");
+
+        //Control: the same payload and key without crit verifies, so the rejection above is the crit
+        //rule and not a signing or key-resolution failure.
+        JwtHeader plainHeader = JwtHeader.ForSigning(algorithm, WellKnownJwkValues.TypeJwt, "k1");
+        string plainJws = await SignCompactAsync(plainHeader, payload, privateKey).ConfigureAwait(false);
+
+        bool plainVerifies = await Jws.VerifyAsync(
+            plainJws, TestSetup.Base64UrlDecoder, Pool, publicKey,
+            MicrosoftCryptographicFunctions.VerifyP256Async, TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.IsTrue(plainVerifies, "a crit-free JWS with a valid signature verifies.");
+    }
+
+
+    /// <summary>Signs <paramref name="header"/>/<paramref name="payload"/> into a compact JWS.</summary>
+    private async Task<string> SignCompactAsync(JwtHeader header, JwtPayload payload, PrivateKeyMemory privateKey)
+    {
+        UnsignedJwt unsigned = new(header, payload);
+        using JwsMessage jws = await unsigned.SignAsync(
+            privateKey, HeaderSerializer, PayloadSerializer, TestSetup.Base64UrlEncoder, Pool,
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        return JwsSerialization.SerializeCompact(jws, TestSetup.Base64UrlEncoder);
+    }
+}


### PR DESCRIPTION
Addresses the consumer-feedback finding that Jws.VerifyAsync and DIDComm signed-unpack never inspected the crit header — a JWS naming an unrecognized critical extension verified true (RFC 7515 section 4.1.11), while the JWE path already enforced it.

- Adds JoseCriticalHeaderValidation as the single crit rule set shared by JWS and JWE.
- Enforces crit in Jws.VerifyAsync (compact), VerifyAndDecodeAsync and the resolver/binder verify (fail closed).
- Rejects a signed DIDComm message whose protected header carries crit (new UnsupportedCriticalHeader).
- JweHeaderProcessing delegates its crit check to the shared validator (behaviour unchanged).

Full suite 5059 green plus a new JwsCriticalHeaderTests. Recommend squash-merge.