### PR TITLE
Wire credential status gate into the OID4VP verifier executor

### DIFF
--- a/src/Verifiable.OAuth/Oid4Vp/HaipOid4VpVerifierExecutor.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/HaipOid4VpVerifierExecutor.cs
@@ -5,6 +5,7 @@ using Verifiable.Core;
 using Verifiable.Core.Assessment;
 using Verifiable.Core.Model.Dcql;
 using Verifiable.Core.Model.SelectiveDisclosure;
+using Verifiable.Core.StatusList;
 using Verifiable.Cryptography;
 using Verifiable.Cryptography.Aead;
 using Verifiable.Cryptography.Context;
@@ -121,7 +122,8 @@ public static class HaipOid4VpVerifierExecutor
         MdocVpVerificationSeams? mdocSeams = null,
         SdCwtVpVerificationSeams? sdCwtSeams = null,
         CommitmentReuseDetectionSeam? saltReuseSeam = null,
-        AssessVpDisclosureDelegate? assessDisclosure = null)
+        AssessVpDisclosureDelegate? assessDisclosure = null,
+        ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken = null)
     {
         ArgumentNullException.ThrowIfNull(headerSerializer);
         ArgumentNullException.ThrowIfNull(payloadSerializer);
@@ -162,7 +164,8 @@ public static class HaipOid4VpVerifierExecutor
             mdocSeams: mdocSeams,
             sdCwtSeams: sdCwtSeams,
             saltReuseSeam: saltReuseSeam,
-            assessDisclosure: assessDisclosure);
+            assessDisclosure: assessDisclosure,
+            resolveVerifiedStatusListToken: resolveVerifiedStatusListToken);
     }
 
 
@@ -200,7 +203,8 @@ public static class HaipOid4VpVerifierExecutor
         MdocVpVerificationSeams? mdocSeams = null,
         SdCwtVpVerificationSeams? sdCwtSeams = null,
         CommitmentReuseDetectionSeam? saltReuseSeam = null,
-        AssessVpDisclosureDelegate? assessDisclosure = null)
+        AssessVpDisclosureDelegate? assessDisclosure = null,
+        ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken = null)
     {
         ArgumentNullException.ThrowIfNull(headerSerializer);
         ArgumentNullException.ThrowIfNull(payloadSerializer);
@@ -238,7 +242,8 @@ public static class HaipOid4VpVerifierExecutor
             mdocSeams: mdocSeams,
             sdCwtSeams: sdCwtSeams,
             saltReuseSeam: saltReuseSeam,
-            assessDisclosure: assessDisclosure);
+            assessDisclosure: assessDisclosure,
+            resolveVerifiedStatusListToken: resolveVerifiedStatusListToken);
     }
 
 
@@ -265,7 +270,8 @@ public static class HaipOid4VpVerifierExecutor
         MdocVpVerificationSeams? mdocSeams,
         SdCwtVpVerificationSeams? sdCwtSeams,
         CommitmentReuseDetectionSeam? saltReuseSeam,
-        AssessVpDisclosureDelegate? assessDisclosure)
+        AssessVpDisclosureDelegate? assessDisclosure,
+        ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken)
     {
         var executor = new OAuthActionExecutor();
 
@@ -586,6 +592,13 @@ public static class HaipOid4VpVerifierExecutor
             Dictionary<string, IReadOnlyDictionary<string, string>> aggregatedClaims =
                 new(StringComparer.Ordinal);
 
+            //IETF Token Status List outcomes per credential, keyed by DCQL credential query id.
+            //Populated only when a status resolver was wired AND the credential carried a
+            //status.status_list reference; surfaced on VerificationSucceeded so the relying party
+            //can act on revocation/suspension without re-parsing the verified vp_token.
+            Dictionary<string, CredentialStatusOutcome> credentialStatuses =
+                new(StringComparer.Ordinal);
+
             //OID4VP 1.0 Appendix B.2.6.1: an mso_mdoc presentation's SessionTranscript
             //binds the wallet's fresh mdoc_generated_nonce, which the wallet carries in
             //the response JWE's 'apu' protected-header parameter (ISO/IEC 18013-7 §B.4.4).
@@ -730,6 +743,18 @@ public static class HaipOid4VpVerifierExecutor
                         failedAt);
                 }
 
+                //The credential's signature and holder binding verified above; now read its
+                //IETF Token Status List entry (the "is it still valid now?" step) when a resolver
+                //was wired and the credential references a status list. CheckCredentialStatusAsync
+                //either records the determinable outcome or returns a fail-closed Fail when the
+                //status is undeterminable.
+                if(await CheckCredentialStatusAsync(
+                    resolveVerifiedStatusListToken, parsed, credentialQueryId, now, credentialStatuses, context, ct)
+                    .ConfigureAwait(false) is { } statusFailure)
+                {
+                    return statusFailure;
+                }
+
                 //Multi-credential vp_token: merge this credential's extracted
                 //claims into the aggregated dictionary under its own query id.
                 //parsed.ExtractedClaims is keyed by credential query id already
@@ -748,7 +773,10 @@ public static class HaipOid4VpVerifierExecutor
             return new VerificationSucceeded(
                 aggregatedClaims,
                 VerifiedAt: verifiedAt,
-                RedirectUri: context.Oid4VpRedirectUri);
+                RedirectUri: context.Oid4VpRedirectUri)
+            {
+                CredentialStatuses = credentialStatuses.Count > 0 ? credentialStatuses : null
+            };
         });
 
         //Sibling handler for the unencrypted direct_post path per OID4VP 1.0
@@ -793,6 +821,10 @@ public static class HaipOid4VpVerifierExecutor
             byte[] vpTokenBytes = Encoding.UTF8.GetBytes(action.VpTokenJson);
 
             Dictionary<string, IReadOnlyDictionary<string, string>> aggregatedClaims =
+                new(StringComparer.Ordinal);
+
+            //IETF Token Status List outcomes per credential (see the encrypted-path handler above).
+            Dictionary<string, CredentialStatusOutcome> credentialStatuses =
                 new(StringComparer.Ordinal);
 
             foreach(CredentialQuery credentialQuery in action.CredentialQueries)
@@ -897,6 +929,15 @@ public static class HaipOid4VpVerifierExecutor
                         failedAt);
                 }
 
+                //IETF Token Status List check (see the encrypted-path handler) — read the
+                //credential's status when a resolver is wired; fail closed on an undeterminable one.
+                if(await CheckCredentialStatusAsync(
+                    resolveVerifiedStatusListToken, parsed, credentialQueryId, now, credentialStatuses, context, ct)
+                    .ConfigureAwait(false) is { } statusFailure)
+                {
+                    return statusFailure;
+                }
+
                 foreach(KeyValuePair<string, IReadOnlyDictionary<string, string>> claim in parsed.ExtractedClaims)
                 {
                     aggregatedClaims[claim.Key] = claim.Value;
@@ -910,7 +951,10 @@ public static class HaipOid4VpVerifierExecutor
             return new VerificationSucceeded(
                 aggregatedClaims,
                 VerifiedAt: verifiedAt,
-                RedirectUri: context.Oid4VpRedirectUri);
+                RedirectUri: context.Oid4VpRedirectUri)
+            {
+                CredentialStatuses = credentialStatuses.Count > 0 ? credentialStatuses : null
+            };
         });
 
         return executor;
@@ -977,6 +1021,83 @@ public static class HaipOid4VpVerifierExecutor
 
     private static readonly IReadOnlyDictionary<CredentialPath, object?> EmptyDisclosedClaims =
         new Dictionary<CredentialPath, object?>();
+
+
+    /// <summary>
+    /// Reads a presented credential's IETF Token Status List entry through the verifier-agnostic
+    /// <see cref="CredentialStatusGate"/> when the credential carries a <c>status.status_list</c>
+    /// reference, recording the outcome under <paramref name="credentialQueryId"/> for surfacing on
+    /// <see cref="VerificationSucceeded.CredentialStatuses"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <see langword="null"/> (continue) when the credential carries no status reference — there
+    /// is nothing to check, with or without a resolver wired — or when the status was read successfully;
+    /// a determinable revoked/suspended outcome is recorded, not failed here, so the relying party can
+    /// apply its own policy to it.
+    /// </para>
+    /// <para>
+    /// Returns a fail-closed <see cref="Fail"/> when the status is undeterminable — the status list's
+    /// subject does not match the reference URI, the list has expired, or the index is out of range —
+    /// because an undeterminable status is not a pass.
+    /// </para>
+    /// <para>
+    /// Throws when the credential <em>references</em> a status list but no
+    /// <see cref="ResolveVerifiedStatusListTokenDelegate"/> was wired: the credential's issuer gated its
+    /// validity on a list the verifier cannot read, so silently treating it as valid would be a security
+    /// gap. This mirrors the mdoc / SD-CWT / disclosure seams, which likewise throw when a presented
+    /// credential needs a seam the executor was not constructed with.
+    /// </para>
+    /// </remarks>
+    private static async ValueTask<Fail?> CheckCredentialStatusAsync(
+        ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken,
+        VpTokenParsed parsed,
+        string credentialQueryId,
+        DateTimeOffset now,
+        Dictionary<string, CredentialStatusOutcome> credentialStatuses,
+        ExchangeContext context,
+        CancellationToken cancellationToken)
+    {
+        //No status reference on the credential -> nothing to check, regardless of whether a resolver
+        //was wired.
+        if(parsed.CredentialStatus is not { } statusReference)
+        {
+            return null;
+        }
+
+        //The credential's issuer gated its validity on a status list, but the executor was constructed
+        //without a resolver to read it. Fail closed as a configuration error -- the same disposition the
+        //mdoc / SD-CWT / disclosure seams take when a presented credential needs a seam that was not
+        //wired -- rather than silently passing an unreadable status.
+        if(resolveVerifiedStatusListToken is null)
+        {
+            throw new InvalidOperationException(
+                $"The presented credential for credential query '{credentialQueryId}' references an IETF " +
+                $"Token Status List ({statusReference}) but the verifier executor was constructed without a " +
+                $"status resolver. Pass resolveVerifiedStatusListToken to HaipOid4VpVerifierExecutor.Create / " +
+                $"CreateWithRegistry (wiring the status-list fetch and verification behind it) to enable " +
+                $"revocation checking.");
+        }
+
+        try
+        {
+            CredentialStatusOutcome outcome = await CredentialStatusGate.CheckAsync(
+                statusReference, resolveVerifiedStatusListToken, now, cancellationToken).ConfigureAwait(false);
+
+            credentialStatuses[credentialQueryId] = outcome;
+
+            return null;
+        }
+        catch(StatusListValidationException exception)
+        {
+            DateTimeOffset failedAt = context.VerifiedAt
+                ?? throw new InvalidOperationException("Request timestamp not found in context.");
+
+            return new Fail(
+                $"Credential status could not be determined for credential query '{credentialQueryId}': {exception.Message}",
+                failedAt);
+        }
+    }
 
 
     private static IMemoryOwner<byte> ExtractMdocGeneratedNonce(

--- a/src/Verifiable.OAuth/Oid4Vp/Server/Oid4VpVerifierFlowTransitions.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/Server/Oid4VpVerifierFlowTransitions.cs
@@ -270,6 +270,7 @@ public static class Oid4VpVerifierFlowTransitions
                                 ExpiresAt = received.ExpiresAt,
                                 Kind = FlowKind.Oid4VpVerifierServer,
                                 Claims = verified.Claims,
+                                CredentialStatuses = verified.CredentialStatuses,
                                 VerifiedAt = verified.VerifiedAt,
                                 RedirectUri = verified.RedirectUri
                             },
@@ -289,6 +290,7 @@ public static class Oid4VpVerifierFlowTransitions
                                 ExpiresAt = unencryptedReceived.ExpiresAt,
                                 Kind = FlowKind.Oid4VpVerifierServer,
                                 Claims = verified.Claims,
+                                CredentialStatuses = verified.CredentialStatuses,
                                 VerifiedAt = verified.VerifiedAt,
                                 RedirectUri = verified.RedirectUri
                             },

--- a/src/Verifiable.OAuth/Oid4Vp/States/PresentationVerifiedState.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/States/PresentationVerifiedState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Verifiable.Core.StatusList;
 
 namespace Verifiable.OAuth.Oid4Vp.States;
 
@@ -44,4 +45,13 @@ public sealed record PresentationVerifiedState: FlowState
     /// and follows the redirect.
     /// </remarks>
     public Uri? RedirectUri { get; init; }
+
+    /// <summary>
+    /// The IETF Token Status List outcomes for the presented credentials, keyed by DCQL credential
+    /// query identifier, carried through from <see cref="VerificationSucceeded.CredentialStatuses"/>.
+    /// <see langword="null"/> when the verifier executor was constructed without a status resolver or
+    /// no presented credential referenced a status list. A relying party hosting the verifier flow
+    /// reads this from the terminal state to act on revocation/suspension.
+    /// </summary>
+    public IReadOnlyDictionary<string, CredentialStatusOutcome>? CredentialStatuses { get; init; }
 }

--- a/src/Verifiable.OAuth/Oid4Vp/VerificationSucceeded.cs
+++ b/src/Verifiable.OAuth/Oid4Vp/VerificationSucceeded.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Verifiable.Core.StatusList;
 using Verifiable.OAuth;
 
 namespace Verifiable.OAuth.Oid4Vp;
@@ -24,6 +25,32 @@ public sealed record VerificationSucceeded(
     DateTimeOffset VerifiedAt,
     Uri? RedirectUri = null): FlowInput
 {
+    /// <summary>
+    /// The IETF Token Status List outcomes for the presented credentials, keyed by DCQL credential
+    /// query identifier, or <see langword="null"/> when none of the presented credentials carried a
+    /// <c>status.status_list</c> reference (so there was nothing to check). A credential that
+    /// <em>does</em> reference a status list is either checked — and recorded here — or, when the
+    /// verifier executor was constructed without a <see cref="ResolveVerifiedStatusListTokenDelegate"/>,
+    /// fails the presentation closed before this result is produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A valid issuer signature only proves a credential was genuinely issued; this carries the
+    /// "is it still valid <em>now</em>?" answer the verifier-agnostic
+    /// <see cref="CredentialStatusGate"/> read after signature and holder-binding verification, so a
+    /// relying party can act on revocation/suspension without re-parsing the verified vp_token. An
+    /// entry's <see cref="CredentialStatusOutcome.IsValid"/> is <see langword="false"/> for a revoked
+    /// (<c>0x01</c>) or suspended (<c>0x02</c>) credential; the raw
+    /// <see cref="CredentialStatusOutcome.Status"/> distinguishes those and application-specific values.
+    /// </para>
+    /// <para>
+    /// An <em>undeterminable</em> status (a status list whose subject does not match the reference URI,
+    /// an expired list, or an out-of-range index) fails the presentation closed at the executor — it
+    /// never reaches this surface as a "valid" outcome.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyDictionary<string, CredentialStatusOutcome>? CredentialStatuses { get; init; }
+
     /// <inheritdoc/>
     public bool Equals(VerificationSucceeded? other)
     {
@@ -39,9 +66,10 @@ public sealed record VerificationSucceeded(
 
         return VerifiedAt == other.VerifiedAt
             && ReferenceEquals(Claims, other.Claims)
+            && ReferenceEquals(CredentialStatuses, other.CredentialStatuses)
             && RedirectUri == other.RedirectUri;
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(Claims, VerifiedAt, RedirectUri);
+    public override int GetHashCode() => HashCode.Combine(Claims, VerifiedAt, RedirectUri, CredentialStatuses);
 }

--- a/test/Verifiable.Tests/OAuth/HostedAuthorizationServer.cs
+++ b/test/Verifiable.Tests/OAuth/HostedAuthorizationServer.cs
@@ -150,7 +150,8 @@ internal sealed class HostedAuthorizationServer
         SdCwtVpVerificationSeams? sdCwtSeams = null,
         CommitmentReuseDetectionSeam? saltReuseSeam = null,
         TimingPolicy? timings = null,
-        Verifiable.OAuth.Siop.ResolveDidVerificationKeyDelegate? resolveDidVerificationKey = null)
+        Verifiable.OAuth.Siop.ResolveDidVerificationKeyDelegate? resolveDidVerificationKey = null,
+        Verifiable.Core.StatusList.ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(timeProvider);
@@ -752,7 +753,8 @@ internal sealed class HostedAuthorizationServer
                     Satisfied = satisfied,
                     OverDisclosed = overDisclosed
                 };
-            });
+            },
+            resolveVerifiedStatusListToken: resolveVerifiedStatusListToken);
 
         //SIOPv2 RP flow's §11.1 ValidateSelfIssuedIdToken handler AND the §12 combined-response
         //ValidateCombinedSiopResponse handler, contributed onto the shared executor alongside the

--- a/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
+++ b/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
@@ -1474,6 +1474,175 @@ internal sealed class Oid4VpFlowIntegrationTests
     }
 
 
+    //The status check is wired into the HAIP verifier executor itself: when the host is built with a
+    //ResolveVerifiedStatusListTokenDelegate, the executor reads each presented credential's status_list
+    //entry through CredentialStatusGate and surfaces the outcome on VerificationSucceeded, which the
+    //verifier PDA carries onto PresentationVerifiedState.CredentialStatuses. This proves the relying
+    //party can act on revocation straight off the terminal state — no re-parse of the verified vp_token.
+    //A determinable revoked status is surfaced, NOT failed, so the RP applies its own policy; the full
+    //cross-device flow still reaches PresentationVerified.
+    [TestMethod]
+    public async Task ExecutorSurfacesCredentialStatusOnPresentationVerified()
+    {
+        const string statusListUri = "https://issuer.example/statuslists/1";
+        const int credentialIndex = 42;
+        const string pidCredentialQueryId = "pid";
+
+        //The mutable list the resolver hands back, standing in for whatever fetched and verified it.
+        //Flipping the bit between the two presentations drives valid -> revoked through the executor.
+        using StatusListType statusList = StatusListType.Create(
+            64, StatusListBitSize.OneBit, Pool, BitOrder.LeastSignificantFirst);
+
+        Verifiable.Core.StatusList.ResolveVerifiedStatusListTokenDelegate resolveStatusList =
+            (uri, ct) => ValueTask.FromResult(
+                new StatusListToken(statusListUri, TimeProvider.GetUtcNow(), statusList));
+
+        await using TestHostShell app = new(TimeProvider, resolveVerifiedStatusListToken: resolveStatusList);
+        using VerifierKeyMaterial verifierKeys = app.RegisterClient(
+            VerifierClientId, VerifierBaseUri, Oid4VpCapabilities);
+
+        (string serializedSdJwt, PrivateKeyMemory holderPrivateKey, PublicKeyMemory issuerPublicKey) =
+            await IssuePidCredentialWithClaimsAsync(
+                "Alice", "Smith", TestContext.CancellationToken,
+                status: new StatusListReference(credentialIndex, statusListUri)).ConfigureAwait(false);
+        using PrivateKeyMemory holderKey = holderPrivateKey;
+        using PublicKeyMemory issuerKey = issuerPublicKey;
+        app.RegisterIssuerTrust(IssuerId, issuerKey);
+
+        Oid4VpWalletClient walletClient =
+            await app.CreateHttpBackedOid4VpWalletClientAsync(
+                verifierKeys,
+                serializedSdJwt,
+                holderKey,
+                TestContext.CancellationToken).ConfigureAwait(false);
+
+        //Drives one full cross-device presentation and returns the verifier's terminal state.
+        async Task<PresentationVerifiedState> PresentAsync(string nonce)
+        {
+            (Uri requestUri, string parHandle) = await app.HandleParAsync(
+                verifierKeys,
+                new TransactionNonce(nonce),
+                CreatePreparedQuery(),
+                TestContext.CancellationToken).ConfigureAwait(false);
+
+            using HttpResponseMessage jarResponse = await app.Host("default").SharedHttpClient!
+                .GetAsync(requestUri, TestContext.CancellationToken).ConfigureAwait(false);
+            jarResponse.EnsureSuccessStatusCode();
+            string compactJar = await jarResponse.Content
+                .ReadAsStringAsync(TestContext.CancellationToken).ConfigureAwait(false);
+
+            PresentationResult result = await walletClient.PresentJarAsync(
+                new PresentJarOptions
+                {
+                    CompactJar = compactJar,
+                    RequestUri = requestUri,
+                    ExpectedVerifierClientId = VerifierClientId,
+                    FlowId = $"wallet-status-{Guid.NewGuid():N}"
+                },
+                TestContext.CancellationToken).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType<ResponseSent>(result.TerminalState,
+                "Wallet PDA must reach ResponseSent after the HTTP response POST.");
+
+            return (PresentationVerifiedState)app.GetFlowState(parHandle).State;
+        }
+
+        //First presentation — the credential's status bit is unset, so the executor surfaces a valid
+        //status alongside the verified claims.
+        PresentationVerifiedState whenValid = await PresentAsync("nonce-status-valid").ConfigureAwait(false);
+
+        Assert.IsNotNull(whenValid.CredentialStatuses,
+            "The executor must surface CredentialStatuses when a status resolver is wired.");
+        Assert.IsTrue(whenValid.CredentialStatuses!.TryGetValue(pidCredentialQueryId, out CredentialStatusOutcome? validOutcome),
+            "The surfaced statuses must be keyed by the DCQL credential query id.");
+        Assert.IsNotNull(validOutcome);
+        Assert.IsTrue(validOutcome.IsValid, "An unset status bit must surface as valid.");
+        Assert.AreEqual(StatusTypes.Valid, validOutcome.Status);
+
+        //Revoke the credential by flipping its bit, then present again. The executor surfaces the revoked
+        //status WITHOUT failing the presentation — the relying party reads it and applies its own policy.
+        statusList[credentialIndex] = StatusTypes.Invalid;
+
+        PresentationVerifiedState whenRevoked = await PresentAsync("nonce-status-revoked").ConfigureAwait(false);
+
+        Assert.IsNotNull(whenRevoked.CredentialStatuses,
+            "The executor must still surface CredentialStatuses after revocation.");
+        Assert.IsTrue(whenRevoked.CredentialStatuses!.TryGetValue(pidCredentialQueryId, out CredentialStatusOutcome? revokedOutcome),
+            "The surfaced statuses must be keyed by the DCQL credential query id.");
+        Assert.IsNotNull(revokedOutcome);
+        Assert.IsFalse(revokedOutcome.IsValid, "After flipping the bit the executor must surface a revoked status.");
+        Assert.AreEqual(StatusTypes.Invalid, revokedOutcome.Status);
+    }
+
+
+    //Fail-closed configuration guard: a credential whose issuer gated its validity on a status list is
+    //NOT accepted when the verifier executor was constructed without a status resolver to read it. The
+    //executor throws server-side (mirroring the mdoc / SD-CWT / disclosure seams), so the verifier's
+    //flow never reaches PresentationVerified — silently treating an unreadable status as valid would be
+    //a security gap.
+    [TestMethod]
+    public async Task ExecutorFailsClosedWhenCredentialReferencesStatusListButNoResolverWired()
+    {
+        const string statusListUri = "https://issuer.example/statuslists/1";
+        const int credentialIndex = 42;
+
+        //No status resolver wired — yet the issued credential references a status list.
+        await using TestHostShell app = new(TimeProvider);
+        using VerifierKeyMaterial verifierKeys = app.RegisterClient(
+            VerifierClientId, VerifierBaseUri, Oid4VpCapabilities);
+
+        (string serializedSdJwt, PrivateKeyMemory holderPrivateKey, PublicKeyMemory issuerPublicKey) =
+            await IssuePidCredentialWithClaimsAsync(
+                "Alice", "Smith", TestContext.CancellationToken,
+                status: new StatusListReference(credentialIndex, statusListUri)).ConfigureAwait(false);
+        using PrivateKeyMemory holderKey = holderPrivateKey;
+        using PublicKeyMemory issuerKey = issuerPublicKey;
+        app.RegisterIssuerTrust(IssuerId, issuerKey);
+
+        Oid4VpWalletClient walletClient =
+            await app.CreateHttpBackedOid4VpWalletClientAsync(
+                verifierKeys, serializedSdJwt, holderKey, TestContext.CancellationToken).ConfigureAwait(false);
+
+        (Uri requestUri, string parHandle) = await app.HandleParAsync(
+            verifierKeys,
+            new TransactionNonce("nonce-status-noresolver"),
+            CreatePreparedQuery(),
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        using HttpResponseMessage jarResponse = await app.Host("default").SharedHttpClient!
+            .GetAsync(requestUri, TestContext.CancellationToken).ConfigureAwait(false);
+        jarResponse.EnsureSuccessStatusCode();
+        string compactJar = await jarResponse.Content
+            .ReadAsStringAsync(TestContext.CancellationToken).ConfigureAwait(false);
+
+        //The wallet POSTs an otherwise-valid presentation. The verifier fails closed on the unreadable
+        //status server-side; whether that surfaces to the wallet as a thrown error or a non-success
+        //response is the transport's concern — the security-relevant assertion is on the verifier's own
+        //flow state, which must not be PresentationVerified.
+        try
+        {
+            await walletClient.PresentJarAsync(
+                new PresentJarOptions
+                {
+                    CompactJar = compactJar,
+                    RequestUri = requestUri,
+                    ExpectedVerifierClientId = VerifierClientId,
+                    FlowId = $"wallet-status-noresolver-{Guid.NewGuid():N}"
+                },
+                TestContext.CancellationToken).ConfigureAwait(false);
+        }
+        catch(Exception exception) when(exception is not OperationCanceledException)
+        {
+            //Tolerated: the verifier's fail-closed guard surfaced to the wallet as an error response.
+        }
+
+        Assert.IsFalse(
+            app.GetFlowState(parHandle).State is PresentationVerifiedState,
+            "A credential that references a status list must not be accepted when the verifier was " +
+            "constructed without a status resolver to read it.");
+    }
+
+
     //Same-device flow — OID4VP 1.0 §8.2, §8.3, §8.3.1, HAIP 1.0 §5.1.
     //
     //NOTE: OID4VP §3.1 describes a different same-device pattern using

--- a/test/Verifiable.Tests/OAuth/TestHostShell.cs
+++ b/test/Verifiable.Tests/OAuth/TestHostShell.cs
@@ -342,7 +342,8 @@ internal sealed class TestHostShell: IAsyncDisposable
         ClaimIssuer<ValidationContext>? vpValidator = null,
         MdocVpVerificationSeams? mdocSeams = null,
         SdCwtVpVerificationSeams? sdCwtSeams = null,
-        CommitmentReuseDetectionSeam? saltReuseSeam = null)
+        CommitmentReuseDetectionSeam? saltReuseSeam = null,
+        Verifiable.Core.StatusList.ResolveVerifiedStatusListTokenDelegate? resolveVerifiedStatusListToken = null)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
 
@@ -359,6 +360,7 @@ internal sealed class TestHostShell: IAsyncDisposable
         MdocSeamsShared = mdocSeams;
         SdCwtSeamsShared = sdCwtSeams;
         SaltReuseSeamShared = saltReuseSeam;
+        StatusListResolverShared = resolveVerifiedStatusListToken;
 
         Default = HostedAuthorizationServer.Build(
             name: "default",
@@ -369,7 +371,8 @@ internal sealed class TestHostShell: IAsyncDisposable
             mdocSeams: MdocSeamsShared,
             sdCwtSeams: SdCwtSeamsShared,
             saltReuseSeam: SaltReuseSeamShared,
-            resolveDidVerificationKey: ResolveSiopDidKey);
+            resolveDidVerificationKey: ResolveSiopDidKey,
+            resolveVerifiedStatusListToken: StatusListResolverShared);
         HostsByName["default"] = Default;
     }
 
@@ -381,6 +384,7 @@ internal sealed class TestHostShell: IAsyncDisposable
     private MdocVpVerificationSeams? MdocSeamsShared { get; }
     private SdCwtVpVerificationSeams? SdCwtSeamsShared { get; }
     private CommitmentReuseDetectionSeam? SaltReuseSeamShared { get; }
+    private Verifiable.Core.StatusList.ResolveVerifiedStatusListTokenDelegate? StatusListResolverShared { get; }
 
     //Multi-host orchestration. The Default entry is added in the constructor;
     //AddHost creates further independent hosts (different roles in a multi-
@@ -436,7 +440,8 @@ internal sealed class TestHostShell: IAsyncDisposable
             vpValidator: VpValidatorShared,
             mdocSeams: MdocSeamsShared,
             sdCwtSeams: SdCwtSeamsShared,
-            resolveDidVerificationKey: ResolveSiopDidKey);
+            resolveDidVerificationKey: ResolveSiopDidKey,
+            resolveVerifiedStatusListToken: StatusListResolverShared);
         HostsByName[name] = host;
 
         return host;


### PR DESCRIPTION
Wires the CredentialStatusGate into the HAIP OID4VP verifier executor so a relying party can act on credential revocation/suspension off the verified result without re-parsing the vp_token.