### PR TITLE
Enforce client-side authorization server issuer uniqueness

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-stryker": {
-      "version": "4.15.0",
+      "version": "4.16.0",
       "commands": [
         "dotnet-stryker"
       ],
@@ -38,7 +38,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.8.0",
+      "version": "18.9.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />
@@ -52,8 +51,8 @@
     <PackageVersion Include="CsCheck" Version="4.7.0" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="LiquidTestReports.Markdown" Version="1.4.3-beta" />
-    <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
+    <PackageVersion Include="System.Reactive" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
   </ItemGroup>
   <!--

--- a/NuGet.config
+++ b/NuGet.config
@@ -20,7 +20,7 @@
       <certificate fingerprint="5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-      <owners>LegionOfTheBouncyCastle;ModelContextProtocol;ModelContextProtocolOfficial;rsuter;patrik;wtfsck;alirezanet;danielpalme;stryker-mutator;MarkZither;AnthonyLloyd;pshkarin;Microsoft;9ee1;commandlineparser;DotLiquid;roastedamoeba;NightOwl888;FlorianRappl;wtfsck;zzzprojects;SharpDevelop;jedisct1;xoofx;ApacheLuceneNet;Microsoft;dotnetfoundation;albi05;jd.cain.jr;joelhulen;aarnott;AndreyAkinshin;dotnetrdf;kurt;codito;kurtmkurtm;nsec;Metalnem;sil-lsdev;sedatk;spectresystems;winsharpfuzz;Lumoin;</owners>
+      <owners>LegionOfTheBouncyCastle;ModelContextProtocol;ModelContextProtocolOfficial;rsuter;patrik;wtfsck;alirezanet;danielpalme;stryker-mutator;MarkZither;AnthonyLloyd;pshkarin;Microsoft;9ee1;commandlineparser;DotLiquid;roastedamoeba;NightOwl888;FlorianRappl;wtfsck;zzzprojects;SharpDevelop;jedisct1;xoofx;ApacheLuceneNet;Microsoft;dotnetfoundation;albi05;jd.cain.jr;joelhulen;aarnott;AndreyAkinshin;dotnetrdf;kurt;codito;kurtmkurtm;nsec;Metalnem;sil-lsdev;sedatk;spectresystems;winsharpfuzz;Lumoin;xunit;</owners>
     </repository>
   </trustedSigners>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
         "version": "10.0.302"
     },
     "msbuild-sdks": {
-        "MSTest.Sdk": "4.2.3"
+        "MSTest.Sdk": "4.3.2"
     },
     "test": {
         "runner": "Microsoft.Testing.Platform"

--- a/src/Verifiable.OAuth/AuthCode/AuthCodeFlowHandlers.cs
+++ b/src/Verifiable.OAuth/AuthCode/AuthCodeFlowHandlers.cs
@@ -354,6 +354,29 @@ public static class AuthCodeFlowHandlers
             ? issValue
             : null;
 
+        //RFC 9207 §2.4 / §4 — when the application supplies a known-authorization-server
+        //resolver, a PRESENT iss must additionally resolve to a positively known,
+        //uniquely-configured authorization server that ordinally matches this
+        //registration's pinned issuer. This closes the mix-up case the per-flow issuer
+        //check cannot: an iss that string-matches the flow's expected issuer yet does not
+        //correspond to a known, uniquely-claimed authorization server in the application's
+        //own configuration. An absent iss is out of scope here — the callback profile
+        //governs whether iss presence is required — and a null resolver opts out entirely.
+        if(iss is not null
+            && infrastructure.IsKnownAuthorizationServerIssuer is not null
+            && !AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+                iss, registration.AuthorizationServerIssuer, infrastructure.IsKnownAuthorizationServerIssuer))
+        {
+            return new AuthCodeFlowEndpointResult
+            {
+                Outcome = AuthCodeFlowEndpointOutcome.BadRequest,
+                ErrorCode = "invalid_request",
+                ErrorDescription =
+                    "The iss parameter does not resolve to a known, uniquely-configured authorization " +
+                    "server matching this registration (RFC 9207 §2.4, §4)."
+            };
+        }
+
         DateTimeOffset now = infrastructure.TimeProvider.GetUtcNow();
 
         AuthorizationCodeReceivedState codeReceived = new AuthorizationCodeReceivedState

--- a/src/Verifiable.OAuth/Client/AuthorizationServerIssuerValidation.cs
+++ b/src/Verifiable.OAuth/Client/AuthorizationServerIssuerValidation.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace Verifiable.OAuth.Client;
+
+/// <summary>
+/// Resolves whether <paramref name="issuer"/> identifies an authorization server the client trusts and
+/// has configured under a UNIQUE issuer identifier, per
+/// <see href="https://www.rfc-editor.org/rfc/rfc9207#section-4">RFC 9207 §4</see>. The application owns
+/// the authorization-server configuration store; this delegate is the library's seam into it. Returning
+/// <see langword="true"/> asserts BOTH that the issuer is one the client trusts AND that it is the sole
+/// authorization server the application configured under that identifier — the §4 "MUST NOT allow
+/// multiple authorization servers to use the same issuer identifier" guarantee the application enforces
+/// in how it answers this resolver. Mirrors <see cref="ClientRegistration"/>'s design: the library does
+/// not supply a registration store.
+/// </summary>
+/// <param name="issuer">
+/// The issuer identifier to resolve, compared by ordinal (RFC 8414 §3.3 / RFC 9207 §2.4) equality.
+/// </param>
+public delegate bool KnownAuthorizationServerIssuerResolver(string issuer);
+
+
+/// <summary>
+/// Client-side <see href="https://www.rfc-editor.org/rfc/rfc9207">RFC 9207</see> authorization-response
+/// issuer validation over an application-owned authorization-server store, reached through a
+/// <see cref="KnownAuthorizationServerIssuerResolver"/>.
+/// </summary>
+[DebuggerDisplay("AuthorizationServerIssuerValidation")]
+public static class AuthorizationServerIssuerValidation
+{
+    /// <summary>
+    /// The <see href="https://www.rfc-editor.org/rfc/rfc9207#section-2.4">RFC 9207 §2.4</see> mix-up
+    /// defense: <see langword="true"/> only when <paramref name="responseIssuer"/> both identifies a
+    /// known, uniquely-configured authorization server (per
+    /// <paramref name="isKnownAuthorizationServerIssuer"/>) AND is identical, by ordinal string
+    /// comparison, to <paramref name="expectedIssuer"/> — the authorization server the request was sent
+    /// to. Shares the ordinal comparison rule with
+    /// <see cref="AuthorizationServerMetadataValidation.IsIssuerMatch"/>. This composes with, rather than
+    /// replaces, the per-flow callback issuer check already performed against a single flow's recorded
+    /// issuer; it additionally requires the issuer to be a positively KNOWN, uniquely-claimed
+    /// authorization server, closing the case where the application's own configuration is the source of
+    /// a shared issuer identifier.
+    /// </summary>
+    /// <param name="responseIssuer">
+    /// The <c>iss</c> an authorization response carried, decoded from its
+    /// <c>application/x-www-form-urlencoded</c> wire form per
+    /// <see href="https://www.rfc-editor.org/rfc/rfc6749#appendix-B">RFC 6749 Appendix B</see>.
+    /// <see langword="null"/> or whitespace-only — an effectively absent <c>iss</c> — is never valid and
+    /// does not throw: this validates untrusted wire input and must reject malformed input rather than
+    /// fault on it.
+    /// </param>
+    /// <param name="expectedIssuer">The issuer of the authorization server the request was sent under.</param>
+    /// <param name="isKnownAuthorizationServerIssuer">
+    /// The application's resolver over its own authorization-server store; see
+    /// <see cref="KnownAuthorizationServerIssuerResolver"/>.
+    /// </param>
+    public static bool IsAuthorizationResponseIssuerValid(
+        string? responseIssuer,
+        Uri expectedIssuer,
+        KnownAuthorizationServerIssuerResolver isKnownAuthorizationServerIssuer)
+    {
+        ArgumentNullException.ThrowIfNull(expectedIssuer);
+        ArgumentNullException.ThrowIfNull(isKnownAuthorizationServerIssuer);
+
+        return !string.IsNullOrWhiteSpace(responseIssuer)
+            && isKnownAuthorizationServerIssuer(responseIssuer)
+            && AuthorizationServerMetadataValidation.IsIssuerIdentifierMatch(responseIssuer, expectedIssuer);
+    }
+}

--- a/src/Verifiable.OAuth/Client/AuthorizationServerMetadataValidation.cs
+++ b/src/Verifiable.OAuth/Client/AuthorizationServerMetadataValidation.cs
@@ -36,9 +36,26 @@ public static class AuthorizationServerMetadataValidation
         ArgumentNullException.ThrowIfNull(metadata);
         ArgumentNullException.ThrowIfNull(expectedIssuerIdentifier);
 
-        return string.Equals(
-            metadata.Issuer.OriginalString,
-            expectedIssuerIdentifier.OriginalString,
-            StringComparison.Ordinal);
+        return IsIssuerIdentifierMatch(metadata.Issuer.OriginalString, expectedIssuerIdentifier);
+    }
+
+
+    /// <summary>
+    /// The code-point-by-code-point issuer-identifier comparison
+    /// <see href="https://www.rfc-editor.org/rfc/rfc8414#section-3.3">RFC 8414 §3.3</see> /
+    /// <see href="https://www.rfc-editor.org/rfc/rfc9207#section-2.4">RFC 9207 §2.4</see>
+    /// require — no Unicode normalization, no URI canonicalization. The single
+    /// comparison rule shared by <see cref="IsIssuerMatch"/> (the metadata-issuer
+    /// consistency gate) and <see cref="AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid"/>
+    /// (the RFC 9207 §2.4 mix-up defense), so both apply the identical rule rather
+    /// than each defining its own.
+    /// </summary>
+    /// <param name="issuerIdentifier">The issuer identifier under comparison.</param>
+    /// <param name="expectedIssuerIdentifier">The issuer identifier it must equal.</param>
+    internal static bool IsIssuerIdentifierMatch(string issuerIdentifier, Uri expectedIssuerIdentifier)
+    {
+        ArgumentNullException.ThrowIfNull(expectedIssuerIdentifier);
+
+        return string.Equals(issuerIdentifier, expectedIssuerIdentifier.OriginalString, StringComparison.Ordinal);
     }
 }

--- a/src/Verifiable.OAuth/Client/OAuthClientInfrastructure.cs
+++ b/src/Verifiable.OAuth/Client/OAuthClientInfrastructure.cs
@@ -234,6 +234,25 @@ public sealed class OAuthClientInfrastructure
     public DpopNonceStoreDelegate? StoreDpopNonce { get; private init; }
 
 
+    //Client-side issuer validation — RFC 9207 §4 authorization-server
+    //issuer uniqueness. Opt-in.
+
+    /// <summary>
+    /// Resolves whether an authorization response's <c>iss</c> identifies a
+    /// known, uniquely-configured authorization server, per
+    /// <see href="https://www.rfc-editor.org/rfc/rfc9207#section-4">RFC 9207
+    /// §4</see>. <see langword="null"/> when the application maintains no
+    /// multi-authorization-server store, in which case the AuthCode callback
+    /// handler applies only the per-flow issuer check. When wired, the callback
+    /// handler additionally requires a PRESENT <c>iss</c> to resolve through this
+    /// delegate to a known authorization server that ordinally matches the one
+    /// the flow targeted — the application owns the store and the §4 uniqueness
+    /// guarantee. Mirrors <see cref="ClientRegistration"/>: the library supplies
+    /// no store.
+    /// </summary>
+    public KnownAuthorizationServerIssuerResolver? IsKnownAuthorizationServerIssuer { get; private init; }
+
+
     /// <summary>
     /// Constructs a fully validated <see cref="OAuthClientInfrastructure"/>.
     /// Every mandatory delegate is checked for non-null at construction so
@@ -259,6 +278,7 @@ public sealed class OAuthClientInfrastructure
         SendJsonPutDelegate? sendJsonPutAsync = null,
         SendJsonDeleteDelegate? sendJsonDeleteAsync = null,
         ParseClientMetadataDelegate? parseClientMetadataAsync = null,
+        KnownAuthorizationServerIssuerResolver? isKnownAuthorizationServerIssuer = null,
         ConstructDpopProofDelegate? constructDpopProofAsync = null,
         DpopKey? dpopKey = null,
         DpopNonceLookupDelegate? lookupDpopNonce = null,
@@ -318,6 +338,7 @@ public sealed class OAuthClientInfrastructure
             SendJsonPutAsync = sendJsonPutAsync,
             SendJsonDeleteAsync = sendJsonDeleteAsync,
             ParseClientMetadataAsync = parseClientMetadataAsync,
+            IsKnownAuthorizationServerIssuer = isKnownAuthorizationServerIssuer,
             ConstructDpopProofAsync = constructDpopProofAsync,
             DpopKey = dpopKey,
             LookupDpopNonce = lookupDpopNonce,

--- a/src/Verifiable.OAuth/Jarm/JarmResponseValidation.cs
+++ b/src/Verifiable.OAuth/Jarm/JarmResponseValidation.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using Verifiable.Cryptography;
 using Verifiable.JCose;
+using Verifiable.OAuth.Client;
 using Verifiable.OAuth.Jar;
 
 namespace Verifiable.OAuth.Jarm;
@@ -26,6 +27,14 @@ namespace Verifiable.OAuth.Jarm;
 /// parameters surface on the result only when every check passed.
 /// </para>
 /// <para>
+/// An optional <see cref="KnownAuthorizationServerIssuerResolver"/> adds the
+/// <see href="https://www.rfc-editor.org/rfc/rfc9207#section-4">RFC 9207 §4</see> known-issuer
+/// gate: an <c>iss</c> that ordinally matches the expected issuer but is absent from the
+/// application's known-issuer store is treated as an invalid issuer, so — exactly like an
+/// unexpected issuer — it never triggers key resolution either. A <see langword="null"/>
+/// resolver keeps the §2.4 ordinal match as the sole issuer check.
+/// </para>
+/// <para>
 /// Signed-and-encrypted (Nested JWT) responses are out of this primitive's scope —
 /// FAPI 2.0 Message Signing §6.1 recommends against response encryption; a deployment
 /// that uses it decrypts the JWE first and passes the inner signed JWT here.
@@ -45,6 +54,7 @@ public static class JarmResponseValidation
     /// <param name="payloadDeserializer">Deserialises the payload JSON into a claim dictionary, so response parameters keep their JSON types (strings, numbers).</param>
     /// <param name="base64UrlDecoder">Base64url decoder.</param>
     /// <param name="memoryPool">Memory pool for transient buffers.</param>
+    /// <param name="isKnownAuthorizationServerIssuer">The application's <see href="https://www.rfc-editor.org/rfc/rfc9207#section-4">RFC 9207 §4</see> known-issuer gate over its own authorization-server store (each configured AS under a UNIQUE issuer identifier); see <see cref="KnownAuthorizationServerIssuerResolver"/>. <see langword="null"/> opts out. Evaluated before any key resolution, alongside the ordinal <c>iss</c> match.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="expirationLeeway">Clock-skew leeway added to <c>exp</c>; defaults to none.</param>
     /// <returns>The per-check validation outcome.</returns>
@@ -58,6 +68,7 @@ public static class JarmResponseValidation
         JwtPayloadDeserializer payloadDeserializer,
         DecodeDelegate base64UrlDecoder,
         MemoryPool<byte> memoryPool,
+        KnownAuthorizationServerIssuerResolver? isKnownAuthorizationServerIssuer = null,
         TimeSpan? expirationLeeway = null,
         CancellationToken cancellationToken = default)
     {
@@ -105,11 +116,13 @@ public static class JarmResponseValidation
             return new JarmResponseValidationResult();
         }
 
-        //§2.4 step 2: iss must identify the expected issuer — checked before any key
-        //resolution per the §5.1 DoS consideration.
+        //§2.4 step 2 + §4: iss must identify the expected issuer and, when a known-issuer
+        //resolver is supplied, resolve to a known, uniquely-configured authorization server —
+        //checked before any key resolution per the §5.1 DoS consideration.
         bool isIssuerValid = claims!.TryGetValue(WellKnownJwtClaimNames.Iss, out object? issValue)
             && issValue is string iss
-            && string.Equals(iss, expectedIssuer, StringComparison.Ordinal);
+            && string.Equals(iss, expectedIssuer, StringComparison.Ordinal)
+            && (isKnownAuthorizationServerIssuer is null || isKnownAuthorizationServerIssuer(iss));
 
         //§2.4 step 3: aud must match the client id used in the authorization request.
         bool isAudienceValid = claims.TryGetValue(WellKnownJwtClaimNames.Aud, out object? audValue)

--- a/test/Verifiable.Tests/Acdc/AcdcReaderTests.cs
+++ b/test/Verifiable.Tests/Acdc/AcdcReaderTests.cs
@@ -60,7 +60,7 @@ internal sealed class AcdcReaderTests
         Assert.AreEqual(AcdcExampleVectors.AttributeSectionSaid, attributeSaid);
         Assert.IsTrue(attribute.Detail.TryGetString("name", out string? name));
         Assert.AreEqual("Sunspot College", name);
-        CollectionAssert.AreEqual(AttributeBlockFieldOrder, attribute.Detail.Keys.ToArray(), "The expanded block preserves field order.");
+        Assert.AreSequenceEqual(AttributeBlockFieldOrder, attribute.Detail.Keys.ToArray(), "The expanded block preserves field order.");
 
         var rule = acdc.Rule as ExpandedAcdcSection;
         Assert.IsNotNull(rule, "The expanded rule section is a block.");

--- a/test/Verifiable.Tests/Apdu/ApduReaderWriterTests.cs
+++ b/test/Verifiable.Tests/Apdu/ApduReaderWriterTests.cs
@@ -96,7 +96,7 @@ internal sealed class ApduReaderWriterTests
 
         ReadOnlySpan<byte> aid = reader.ReadBytes(5);
 
-        Assert.AreEqual(5, aid.Length);
+        Assert.HasCount(5, aid);
         Assert.AreEqual((byte)0xA0, aid[0]);
         Assert.AreEqual((byte)0x08, aid[4]);
         Assert.AreEqual(2, reader.Remaining);
@@ -111,7 +111,7 @@ internal sealed class ApduReaderWriterTests
         reader.ReadByte();
         ReadOnlySpan<byte> remaining = reader.ReadRemainingBytes();
 
-        Assert.AreEqual(2, remaining.Length);
+        Assert.HasCount(2, remaining);
         Assert.IsTrue(reader.IsEmpty);
     }
 
@@ -123,7 +123,7 @@ internal sealed class ApduReaderWriterTests
 
         ReadOnlySpan<byte> peeked = reader.PeekBytes(2);
 
-        Assert.AreEqual(2, peeked.Length);
+        Assert.HasCount(2, peeked);
         Assert.AreEqual(0, reader.Consumed);
     }
 

--- a/test/Verifiable.Tests/Apdu/CardSimulatorPaceTests.cs
+++ b/test/Verifiable.Tests/Apdu/CardSimulatorPaceTests.cs
@@ -108,8 +108,8 @@ internal sealed class CardSimulatorPaceTests
         {
             Assert.AreEqual(CardLifecyclePhase.SecureMessaging, card.Phase,
                 "PACE must leave the card in the Secure Messaging phase.");
-            Assert.AreEqual(16, encryptionKey.AsReadOnlySpan().Length, "KSenc is an AES-128 key.");
-            Assert.AreEqual(16, macKey.AsReadOnlySpan().Length, "KSmac is an AES-128 key.");
+            Assert.HasCount(16, encryptionKey.AsReadOnlySpan(), "KSenc is an AES-128 key.");
+            Assert.HasCount(16, macKey.AsReadOnlySpan(), "KSmac is an AES-128 key.");
         }
     }
 
@@ -131,8 +131,8 @@ internal sealed class CardSimulatorPaceTests
         {
             Assert.AreEqual(CardLifecyclePhase.SecureMessaging, card.Phase,
                 "PACE with Integrated Mapping must leave the card in the Secure Messaging phase.");
-            Assert.AreEqual(16, encryptionKey.AsReadOnlySpan().Length, "KSenc is an AES-128 key.");
-            Assert.AreEqual(16, macKey.AsReadOnlySpan().Length, "KSmac is an AES-128 key.");
+            Assert.HasCount(16, encryptionKey.AsReadOnlySpan(), "KSenc is an AES-128 key.");
+            Assert.HasCount(16, macKey.AsReadOnlySpan(), "KSmac is an AES-128 key.");
         }
     }
 
@@ -161,8 +161,8 @@ internal sealed class CardSimulatorPaceTests
             {
                 Assert.AreEqual(CardLifecyclePhase.SecureMessaging, card.Phase,
                     "PACE with Chip Authentication Mapping must leave the card in the Secure Messaging phase.");
-                Assert.AreEqual(16, encryptionKey.AsReadOnlySpan().Length, "KSenc is an AES-128 key.");
-                Assert.AreEqual(16, macKey.AsReadOnlySpan().Length, "KSmac is an AES-128 key.");
+                Assert.HasCount(16, encryptionKey.AsReadOnlySpan(), "KSenc is an AES-128 key.");
+                Assert.HasCount(16, macKey.AsReadOnlySpan(), "KSmac is an AES-128 key.");
             }
         }
     }

--- a/test/Verifiable.Tests/Apdu/CscaMasterListTests.cs
+++ b/test/Verifiable.Tests/Apdu/CscaMasterListTests.cs
@@ -52,13 +52,14 @@ internal sealed class CscaMasterListTests
 
         Assert.AreEqual(0, parsed.Version, "The master-list version is 0.");
         Assert.HasCount(2, parsed.CountrySigningCertificateAuthorities, "Both CSCA certificates must be extracted.");
-        CollectionAssert.AreEquivalent(
+        Assert.AreSequenceEqual(
             new[] { Convert.ToHexString(first.RawData), Convert.ToHexString(second.RawData) },
             new[]
             {
                 Convert.ToHexString(parsed.CountrySigningCertificateAuthorities[0].AsReadOnlySpan()),
                 Convert.ToHexString(parsed.CountrySigningCertificateAuthorities[1].AsReadOnlySpan())
             },
+            SequenceOrder.InAnyOrder,
             "Each extracted CSCA certificate must be byte-for-byte the one the master list carried.");
         Assert.AreEqual(Convert.ToHexString(signer.RawData), Convert.ToHexString(parsed.SignerCertificate.AsReadOnlySpan()),
             "The signer certificate must be the Master List Signer the CMS embedded.");

--- a/test/Verifiable.Tests/Apdu/CtapNfcFragmentationWorkedExampleTests.cs
+++ b/test/Verifiable.Tests/Apdu/CtapNfcFragmentationWorkedExampleTests.cs
@@ -119,8 +119,8 @@ internal sealed class CtapNfcFragmentationWorkedExampleTests
 
         //Exactly the two GET RESPONSE commands the spec's worked example shows, byte-for-byte.
         Assert.HasCount(2, issuedGetResponseCommands);
-        CollectionAssert.AreEqual(thirdCommand, issuedGetResponseCommands[0]);
-        CollectionAssert.AreEqual(fourthCommand, issuedGetResponseCommands[1]);
+        Assert.AreSequenceEqual(thirdCommand, issuedGetResponseCommands[0]);
+        Assert.AreSequenceEqual(fourthCommand, issuedGetResponseCommands[1]);
 
         //The assembled data is exactly the three responses' data fields (status word stripped), concatenated.
         byte[] expectedData =
@@ -129,7 +129,7 @@ internal sealed class CtapNfcFragmentationWorkedExampleTests
             .. thirdResponse.AsSpan(0, thirdResponse.Length - ApduConstants.StatusWordSize).ToArray(),
             .. fourthResponse.AsSpan(0, fourthResponse.Length - ApduConstants.StatusWordSize).ToArray()
         ];
-        CollectionAssert.AreEqual(expectedData, assembled.Data.ToArray());
+        Assert.AreSequenceEqual(expectedData, assembled.Data.ToArray());
     }
 
     /// <summary>

--- a/test/Verifiable.Tests/Apdu/CtapNfcResponderTests.cs
+++ b/test/Verifiable.Tests/Apdu/CtapNfcResponderTests.cs
@@ -195,7 +195,7 @@ internal sealed class CtapNfcResponderTests
 
         Assert.IsTrue(response.AsReadOnlySpan().SequenceEqual(scriptedResponse));
         Assert.IsNotNull(capturedRequest);
-        CollectionAssert.AreEqual(request, capturedRequest,
+        Assert.AreSequenceEqual(request, capturedRequest,
             "The responder must deframe NFCCTAP_MSG down to exactly the opaque CTAP2 envelope.");
     }
 

--- a/test/Verifiable.Tests/Apdu/CtapNfcTransportTests.cs
+++ b/test/Verifiable.Tests/Apdu/CtapNfcTransportTests.cs
@@ -74,7 +74,7 @@ internal sealed class CtapNfcTransportTests
             WellKnownCtapCommandParameters.SupportsGetResponseP1Bit, 0x00,
             0x00, 0x00, 0x01, .. request, 0x00, 0x00
         ];
-        CollectionAssert.AreEqual(expectedCommand, capturedCommand);
+        Assert.AreSequenceEqual(expectedCommand, capturedCommand);
     }
 
     [TestMethod]
@@ -116,7 +116,7 @@ internal sealed class CtapNfcTransportTests
             WellKnownCtapCommandParameters.ClassByte, WellKnownCtapInstructionCodes.NfcCtapGetResponse.Code,
             0x00, 0x00, 0x00
         ];
-        CollectionAssert.AreEqual(expectedPoll, pollCommand);
+        Assert.AreSequenceEqual(expectedPoll, pollCommand);
     }
 
     [TestMethod]
@@ -150,7 +150,7 @@ internal sealed class CtapNfcTransportTests
             WellKnownCtapCommandParameters.ClassByte, WellKnownCtapInstructionCodes.NfcCtapGetResponse.Code,
             WellKnownCtapCommandParameters.CancelP1, 0x00, 0x00
         ];
-        CollectionAssert.AreEqual(expectedCancel, commands[1]);
+        Assert.AreSequenceEqual(expectedCancel, commands[1]);
     }
 
     [TestMethod]

--- a/test/Verifiable.Tests/Apdu/WellKnownAidTests.cs
+++ b/test/Verifiable.Tests/Apdu/WellKnownAidTests.cs
@@ -14,7 +14,7 @@ internal sealed class WellKnownAidTests
     {
         ReadOnlySpan<byte> piv = WellKnownAid.Piv;
 
-        Assert.AreEqual(9, piv.Length);
+        Assert.HasCount(9, piv);
         Assert.AreEqual((byte)0xA0, piv[0]);
         Assert.AreEqual((byte)0x00, piv[8]);
     }
@@ -24,7 +24,7 @@ internal sealed class WellKnownAidTests
     {
         ReadOnlySpan<byte> mrtd = WellKnownAid.Mrtd;
 
-        Assert.AreEqual(7, mrtd.Length);
+        Assert.HasCount(7, mrtd);
         Assert.AreEqual((byte)0xA0, mrtd[0]);
         Assert.AreEqual((byte)0x01, mrtd[6]);
     }
@@ -34,7 +34,7 @@ internal sealed class WellKnownAidTests
     {
         ReadOnlySpan<byte> fido = WellKnownAid.Fido;
 
-        Assert.AreEqual(8, fido.Length);
+        Assert.HasCount(8, fido);
         Assert.AreEqual((byte)0xA0, fido[0]);
         Assert.AreEqual((byte)0x01, fido[7]);
     }

--- a/test/Verifiable.Tests/Base64UrlRoundtripTests.cs
+++ b/test/Verifiable.Tests/Base64UrlRoundtripTests.cs
@@ -38,7 +38,7 @@ namespace Verifiable.Tests
                 byte[] ourDecoded = decodedOwner.Memory.ToArray();
                 
                 //Verify roundtrip works.
-                CollectionAssert.AreEqual(originalData, ourDecoded, "Our Base64Url roundtrip failed");
+                Assert.AreSequenceEqual(originalData, ourDecoded, "Our Base64Url roundtrip failed");
 
                 //Compare with .NET Base64 reference implementation.
                 string netBase64 = Convert.ToBase64String(originalData);
@@ -52,7 +52,7 @@ namespace Verifiable.Tests
                 byte[] netDecoded = netDecodedOwner.Memory.ToArray();
 
                 //Should decode .NET Base64Url correctly.
-                CollectionAssert.AreEqual(originalData, netDecoded, "Failed to decode .NET Base64Url");                
+                Assert.AreSequenceEqual(originalData, netDecoded, "Failed to decode .NET Base64Url");                
             }
         }
 

--- a/test/Verifiable.Tests/Cesr/CesrCountCodeCodecTests.cs
+++ b/test/Verifiable.Tests/Cesr/CesrCountCodeCodecTests.cs
@@ -146,8 +146,8 @@ internal sealed class CesrCountCodeCodecTests
             Assert.AreEqual(bodyBytes, counter.BinaryByteCount, "The count must describe the exact binary span of the same group.");
 
             //Sanity: the binary primitive lengths equal the per-primitive triplet spans implied by their qb64.
-            Assert.AreEqual(first.Length / 4 * 3, firstBinary.Memory.Span[..(first.Length / 4 * 3)].Length);
-            Assert.AreEqual(second.Length / 4 * 3, secondBinary.Memory.Span[..(second.Length / 4 * 3)].Length);
+            Assert.HasCount(first.Length / 4 * 3, firstBinary.Memory.Span[..(first.Length / 4 * 3)]);
+            Assert.HasCount(second.Length / 4 * 3, secondBinary.Memory.Span[..(second.Length / 4 * 3)]);
         }
     }
 

--- a/test/Verifiable.Tests/Cesr/CesrFieldMapCodecTests.cs
+++ b/test/Verifiable.Tests/Cesr/CesrFieldMapCodecTests.cs
@@ -65,7 +65,7 @@ internal sealed class CesrFieldMapCodecTests
         }
 
         Assert.AreEqual(end, offset);
-        CollectionAssert.AreEqual(ExpectedFlatLabels, labels);
+        Assert.AreSequenceEqual(ExpectedFlatLabels, labels);
         Assert.HasCount(6, values);
         Assert.AreEqual(1, values[0]);
         Assert.IsTrue((bool)values[1]!);
@@ -229,7 +229,7 @@ internal sealed class CesrFieldMapCodecTests
 
         MessageFieldMap fields = CesrFieldMapCodec.DecodeFieldMap(native.Memory, BaseMemoryPool.Shared);
 
-        CollectionAssert.AreEqual(ExpectedFlatLabels, new List<string>(fields.Keys));
+        Assert.AreSequenceEqual(ExpectedFlatLabels, new List<string>(fields.Keys));
         Assert.AreEqual(1, fields["a"]);
         Assert.IsTrue((bool)fields["b"]!);
         Assert.AreEqual("hello", fields["c"]);

--- a/test/Verifiable.Tests/Cesr/CesrStreamReaderTests.cs
+++ b/test/Verifiable.Tests/Cesr/CesrStreamReaderTests.cs
@@ -270,7 +270,7 @@ internal sealed class CesrStreamReaderTests
         Assert.HasCount(1, tokens);
         Assert.AreEqual(CesrTokenKind.NonNative, tokens[0].Kind);
         Assert.AreEqual(CesrSerializationKind.Json, tokens[0].Serialization);
-        CollectionAssert.AreEqual(json, tokens[0].Body, "The whole serialization is yielded as the body.");
+        Assert.AreSequenceEqual(json, tokens[0].Body, "The whole serialization is yielded as the body.");
     }
 
 
@@ -296,10 +296,10 @@ internal sealed class CesrStreamReaderTests
         Assert.AreEqual(CesrTokenKind.NonNative, tokens[1].Kind);
         Assert.AreEqual(CesrSerializationKind.Json, tokens[1].Serialization, "The interleaved body is JSON.");
         Assert.AreEqual(domain, tokens[1].Domain, "The non-native token records the surrounding stream's domain.");
-        CollectionAssert.AreEqual(expectedJson, tokens[1].Body, "The whole JSON serialization is yielded as the body.");
+        Assert.AreSequenceEqual(expectedJson, tokens[1].Body, "The whole JSON serialization is yielded as the body.");
 
         Assert.AreEqual(CesrTokenKind.CountGroup, tokens[2].Kind);
-        CollectionAssert.AreEqual(expectedGroupBody, tokens[2].Body, "The count group after the JSON body still parses.");
+        Assert.AreSequenceEqual(expectedGroupBody, tokens[2].Body, "The count group after the JSON body still parses.");
     }
 
 
@@ -316,7 +316,7 @@ internal sealed class CesrStreamReaderTests
         Assert.AreEqual(CesrDomain.Binary, tokens[1].Domain);
         Assert.AreEqual("-V", tokens[1].Code, "The group is an attachment group.");
         Assert.AreEqual(expectedBody.Length / 3, tokens[1].Count, "The count is the group body's triplet count.");
-        CollectionAssert.AreEqual(expectedBody, tokens[1].Body, "The framed body is exactly the concatenated primitives.");
+        Assert.AreSequenceEqual(expectedBody, tokens[1].Body, "The framed body is exactly the concatenated primitives.");
 
         //The body descends into the framed primitives (the test owns the per-primitive lengths).
         using(CesrParsedPrimitive key = CesrPrimitiveCodec.DecodeBinary(tokens[1].Body.AsSpan(0, firstPrimitiveLength), BaseMemoryPool.Shared))
@@ -346,7 +346,7 @@ internal sealed class CesrStreamReaderTests
         Assert.AreEqual(CesrDomain.Text, tokens[1].Domain);
         Assert.AreEqual("-V", tokens[1].Code, "The group is an attachment group.");
         Assert.AreEqual(expectedBody.Length / 4, tokens[1].Count, "The count is the group body's quadlet count.");
-        CollectionAssert.AreEqual(expectedBody, tokens[1].Body, "The framed body is exactly the concatenated primitives as qb64 characters.");
+        Assert.AreSequenceEqual(expectedBody, tokens[1].Body, "The framed body is exactly the concatenated primitives as qb64 characters.");
 
         //The body descends into the framed primitives, decoded from their qb64 text (the test owns the per-primitive lengths).
         string bodyText = Encoding.ASCII.GetString(tokens[1].Body);

--- a/test/Verifiable.Tests/Cesr/CesrStreamWriterTests.cs
+++ b/test/Verifiable.Tests/Cesr/CesrStreamWriterTests.cs
@@ -61,7 +61,7 @@ internal sealed class CesrStreamWriterTests
         Assert.AreEqual(CesrTokenKind.CountGroup, tokens[1].Kind);
         Assert.AreEqual("-V", tokens[1].Code);
         Assert.AreEqual(body.Length / 3, tokens[1].Count);
-        CollectionAssert.AreEqual(body, tokens[1].Body);
+        Assert.AreSequenceEqual(body, tokens[1].Body);
     }
 
 
@@ -99,7 +99,7 @@ internal sealed class CesrStreamWriterTests
         Assert.AreEqual(CesrDomain.Text, tokens[1].Domain);
         Assert.AreEqual("-V", tokens[1].Code);
         Assert.AreEqual(body.Length / 4, tokens[1].Count);
-        CollectionAssert.AreEqual(body, tokens[1].Body);
+        Assert.AreSequenceEqual(body, tokens[1].Body);
     }
 
 

--- a/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha256Tests.cs
+++ b/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha256Tests.cs
@@ -144,9 +144,9 @@ internal sealed class AesCbcHmacSha256Tests
         using AeadEncryptResult encrypted = await MicrosoftKeyAgreementFunctions.AesCbcHmacSha256EncryptAsync(
             plaintext, encryptKey, encryptAad, Pool, TestContext.CancellationToken).ConfigureAwait(false);
 
-        Assert.AreEqual(16, encrypted.Iv.AsReadOnlySpan().Length, "A128CBC-HS256 IV must be one AES block.");
-        Assert.AreEqual(16, encrypted.Tag.AsReadOnlySpan().Length, "A128CBC-HS256 tag must be half the HMAC-SHA-256 output.");
-        Assert.AreEqual(32, encrypted.Ciphertext.AsReadOnlySpan().Length,
+        Assert.HasCount(16, encrypted.Iv.AsReadOnlySpan(), "A128CBC-HS256 IV must be one AES block.");
+        Assert.HasCount(16, encrypted.Tag.AsReadOnlySpan(), "A128CBC-HS256 tag must be half the HMAC-SHA-256 output.");
+        Assert.HasCount(32, encrypted.Ciphertext.AsReadOnlySpan(),
             "PKCS#7 must pad the 24-byte plaintext to two full AES blocks.");
 
         using AdditionalData decryptAad = AadFromHex(VectorAad);

--- a/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha384Tests.cs
+++ b/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha384Tests.cs
@@ -145,9 +145,9 @@ internal sealed class AesCbcHmacSha384Tests
         using AeadEncryptResult encrypted = await MicrosoftKeyAgreementFunctions.AesCbcHmacSha384EncryptAsync(
             plaintext, encryptKey, encryptAad, Pool, TestContext.CancellationToken).ConfigureAwait(false);
 
-        Assert.AreEqual(16, encrypted.Iv.AsReadOnlySpan().Length, "A192CBC-HS384 IV must be one AES block.");
-        Assert.AreEqual(24, encrypted.Tag.AsReadOnlySpan().Length, "A192CBC-HS384 tag must be half the HMAC-SHA-384 output.");
-        Assert.AreEqual(32, encrypted.Ciphertext.AsReadOnlySpan().Length,
+        Assert.HasCount(16, encrypted.Iv.AsReadOnlySpan(), "A192CBC-HS384 IV must be one AES block.");
+        Assert.HasCount(24, encrypted.Tag.AsReadOnlySpan(), "A192CBC-HS384 tag must be half the HMAC-SHA-384 output.");
+        Assert.HasCount(32, encrypted.Ciphertext.AsReadOnlySpan(),
             "PKCS#7 must pad the 24-byte plaintext to two full AES blocks.");
 
         using AdditionalData decryptAad = AadFromHex(VectorAad);

--- a/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha512Tests.cs
+++ b/test/Verifiable.Tests/Cryptography/Aead/AesCbcHmacSha512Tests.cs
@@ -145,9 +145,9 @@ internal sealed class AesCbcHmacSha512Tests
         using AeadEncryptResult encrypted = await MicrosoftKeyAgreementFunctions.AesCbcHmacSha512EncryptAsync(
             plaintext, encryptKey, encryptAad, Pool, TestContext.CancellationToken).ConfigureAwait(false);
 
-        Assert.AreEqual(16, encrypted.Iv.AsReadOnlySpan().Length, "A256CBC-HS512 IV must be one AES block.");
-        Assert.AreEqual(32, encrypted.Tag.AsReadOnlySpan().Length, "A256CBC-HS512 tag must be half the HMAC-SHA-512 output.");
-        Assert.AreEqual(32, encrypted.Ciphertext.AsReadOnlySpan().Length,
+        Assert.HasCount(16, encrypted.Iv.AsReadOnlySpan(), "A256CBC-HS512 IV must be one AES block.");
+        Assert.HasCount(32, encrypted.Tag.AsReadOnlySpan(), "A256CBC-HS512 tag must be half the HMAC-SHA-512 output.");
+        Assert.HasCount(32, encrypted.Ciphertext.AsReadOnlySpan(),
             "PKCS#7 must pad the 24-byte plaintext to two full AES blocks.");
 
         using AdditionalData decryptAad = AadFromHex(VectorAad);

--- a/test/Verifiable.Tests/Cryptography/Aead/ConcatKdfMultiRoundTests.cs
+++ b/test/Verifiable.Tests/Cryptography/Aead/ConcatKdfMultiRoundTests.cs
@@ -58,7 +58,7 @@ internal sealed class ConcatKdfMultiRoundTests
         byte[] expected = ReferenceConcatKdf(z, algorithmId, [], [], keydataLenBits, committedTag: []);
 
         using SymmetricKeyMemory derivedKey = derived.UseKey();
-        Assert.AreEqual(keydataLenBits / 8, derivedKey.AsReadOnlySpan().Length,
+        Assert.HasCount(keydataLenBits / 8, derivedKey.AsReadOnlySpan(),
             "The single-round derivation must produce exactly keydataLenBits / 8 octets.");
         Assert.AreEqual(Convert.ToHexString(expected), Convert.ToHexString(derivedKey.AsReadOnlySpan()),
             "The ≤256-bit single-round path must remain byte identical to the reference SHA-256 oracle.");
@@ -84,7 +84,7 @@ internal sealed class ConcatKdfMultiRoundTests
         byte[] expected = ReferenceConcatKdf(z, algorithmId, [], [], keydataLenBits: 512, committedTag: []);
 
         using SymmetricKeyMemory derivedKey = derived.UseKey();
-        Assert.AreEqual(64, derivedKey.AsReadOnlySpan().Length,
+        Assert.HasCount(64, derivedKey.AsReadOnlySpan(),
             "A 512-bit derivation must produce 64 octets.");
         Assert.AreEqual(Convert.ToHexString(expected), Convert.ToHexString(derivedKey.AsReadOnlySpan()),
             "The 512-bit derivation must equal SHA256(round 1) || SHA256(round 2) of the reference oracle.");

--- a/test/Verifiable.Tests/Cryptography/BouncyCastleCryptographicTests.cs
+++ b/test/Verifiable.Tests/Cryptography/BouncyCastleCryptographicTests.cs
@@ -152,7 +152,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(1312, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(1312, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -188,7 +188,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(1952, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(1952, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -237,7 +237,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(2592, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(2592, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -261,7 +261,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(800, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(800, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -283,7 +283,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(1184, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(1184, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -328,7 +328,7 @@ namespace Verifiable.Tests.Cryptography
             using var publicKey = keys.PublicKey;
             using var privateKey = keys.PrivateKey;
 
-            Assert.AreEqual(1568, publicKey.AsReadOnlySpan().Length);
+            Assert.HasCount(1568, publicKey.AsReadOnlySpan());
             Assert.IsGreaterThan(0, privateKey.AsReadOnlySpan().Length);
         }
 
@@ -398,8 +398,8 @@ namespace Verifiable.Tests.Cryptography
 
             using var receiverSecret = decapsulate(privateKey.AsReadOnlyMemory(), ct.Memory, BaseMemoryPool.Shared);
 
-            Assert.AreEqual(32, ss.Memory.Length);
-            Assert.AreEqual(32, receiverSecret.Memory.Length);
+            Assert.HasCount(32, ss.Memory);
+            Assert.HasCount(32, receiverSecret.Memory);
             Assert.IsTrue(ss.Memory.Span.SequenceEqual(receiverSecret.Memory.Span));
         }
     }

--- a/test/Verifiable.Tests/Cryptography/BrainpoolSignVerifyTests.cs
+++ b/test/Verifiable.Tests/Cryptography/BrainpoolSignVerifyTests.cs
@@ -145,7 +145,7 @@ internal sealed class BrainpoolSignVerifyTests
                 cancellationToken).ConfigureAwait(false);
             try
             {
-                Assert.AreEqual(expectedSignatureLength, signature.AsReadOnlySpan().Length,
+                Assert.HasCount(expectedSignatureLength, signature.AsReadOnlySpan(),
                     "IEEE P1363 signature length must match 2× the curve field byte size.");
 
                 (bool valid, CryptoEvent? _) = await verifyAsync(

--- a/test/Verifiable.Tests/Cryptography/EllipticCurveUtilitiesPropertyTests.cs
+++ b/test/Verifiable.Tests/Cryptography/EllipticCurveUtilitiesPropertyTests.cs
@@ -40,7 +40,7 @@ namespace Verifiable.Tests.Cryptography
                     byte[] decompressedY = EllipticCurveUtilities.Decompress(compressedPoint, curveType);
 
                     //Ensure the decompressed Y matches the original Y.
-                    Assert.AreEqual(publicKeyY, decompressedY);
+                    Assert.AreSequenceEqual(publicKeyY, decompressedY);
                 }
             });
         }

--- a/test/Verifiable.Tests/Cryptography/EllipticCurveUtilitiesTests.cs
+++ b/test/Verifiable.Tests/Cryptography/EllipticCurveUtilitiesTests.cs
@@ -110,7 +110,7 @@ namespace Verifiable.Tests.Cryptography
 
             byte[] evenCompressedPoint = EllipticCurveUtilities.Compress(td.PublicKeyMaterialX, td.PublicKeyMaterialY);
             byte[] evenUncompressedY = EllipticCurveUtilities.Decompress(evenCompressedPoint, curveType);
-            CollectionAssert.AreEqual(td.PublicKeyMaterialY, evenUncompressedY);
+            Assert.AreSequenceEqual(td.PublicKeyMaterialY, evenUncompressedY);
         }
 
 
@@ -147,7 +147,7 @@ namespace Verifiable.Tests.Cryptography
 
             ReadOnlySpan<byte> x = EllipticCurveUtilities.SliceXCoordinate(point);
 
-            Assert.AreEqual(EllipticCurveConstants.P256.PointArrayLength, x.Length,
+            Assert.HasCount(EllipticCurveConstants.P256.PointArrayLength, x,
                 "X coordinate length must match P-256 point array length.");
             Assert.IsTrue(x.SequenceEqual(point.AsSpan(1, EllipticCurveConstants.P256.PointArrayLength)),
                 "X coordinate bytes must match bytes 1 to 32.");
@@ -165,7 +165,7 @@ namespace Verifiable.Tests.Cryptography
 
             ReadOnlySpan<byte> y = EllipticCurveUtilities.SliceYCoordinate(point);
 
-            Assert.AreEqual(EllipticCurveConstants.P256.PointArrayLength, y.Length,
+            Assert.HasCount(EllipticCurveConstants.P256.PointArrayLength, y,
                 "Y coordinate length must match P-256 point array length.");
             Assert.IsTrue(y.SequenceEqual(point.AsSpan(1 + EllipticCurveConstants.P256.PointArrayLength, EllipticCurveConstants.P256.PointArrayLength)),
                 "Y coordinate bytes must match bytes 33 to 64.");
@@ -183,7 +183,7 @@ namespace Verifiable.Tests.Cryptography
 
             ReadOnlySpan<byte> x = EllipticCurveUtilities.SliceXCoordinate(point);
 
-            Assert.AreEqual(EllipticCurveConstants.P384.PointArrayLength, x.Length,
+            Assert.HasCount(EllipticCurveConstants.P384.PointArrayLength, x,
                 "X coordinate length must match P-384 point array length.");
             Assert.IsTrue(x.SequenceEqual(point.AsSpan(1, EllipticCurveConstants.P384.PointArrayLength)),
                 "X coordinate bytes must match bytes 1 to 48.");
@@ -201,7 +201,7 @@ namespace Verifiable.Tests.Cryptography
 
             ReadOnlySpan<byte> y = EllipticCurveUtilities.SliceYCoordinate(point);
 
-            Assert.AreEqual(EllipticCurveConstants.P384.PointArrayLength, y.Length,
+            Assert.HasCount(EllipticCurveConstants.P384.PointArrayLength, y,
                 "Y coordinate length must match P-384 point array length.");
             Assert.IsTrue(y.SequenceEqual(point.AsSpan(1 + EllipticCurveConstants.P384.PointArrayLength, EllipticCurveConstants.P384.PointArrayLength)),
                 "Y coordinate bytes must match bytes 49 to 96.");

--- a/test/Verifiable.Tests/Cryptography/KeyExtensionsHmacTests.cs
+++ b/test/Verifiable.Tests/Cryptography/KeyExtensionsHmacTests.cs
@@ -30,7 +30,7 @@ internal sealed class KeyExtensionsHmacTests
             TestContext.CancellationToken).ConfigureAwait(false);
 
         byte[] viaBcl = HMACSHA256.HashData(keyBytes, message);
-        CollectionAssert.AreEqual(viaBcl, viaExtension.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(viaBcl, viaExtension.AsReadOnlySpan().ToArray());
     }
 
 

--- a/test/Verifiable.Tests/Cryptography/MultibaseEncodingTests.cs
+++ b/test/Verifiable.Tests/Cryptography/MultibaseEncodingTests.cs
@@ -149,7 +149,7 @@ namespace Verifiable.Tests.Cryptography
             td.PublicKeyMulticodecHeader.CopyTo(expectedData);
             compressed.CopyTo(expectedData.AsSpan(td.PublicKeyMulticodecHeader.Length));
 
-            CollectionAssert.AreEqual(expectedData, decodedWithHeader);
+            Assert.AreSequenceEqual(expectedData, decodedWithHeader);
         }
 
 

--- a/test/Verifiable.Tests/Cryptography/RsaUtilitiesTests.cs
+++ b/test/Verifiable.Tests/Cryptography/RsaUtilitiesTests.cs
@@ -90,13 +90,13 @@ namespace Verifiable.Tests.Cryptography
             rawRsa2048[0] = 0xFF;
             byte[] decoded2048 = RsaUtilities.Decode(rawRsa2048);
             Assert.HasCount(RsaUtilities.Rsa2048ModulusLength, decoded2048);
-            CollectionAssert.AreEqual(rawRsa2048, decoded2048);
+            Assert.AreSequenceEqual(rawRsa2048, decoded2048);
 
             byte[] rawRsa4096 = new byte[RsaUtilities.Rsa4096ModulusLength];
             rawRsa4096[0] = 0xFF;
             byte[] decoded4096 = RsaUtilities.Decode(rawRsa4096);
             Assert.HasCount(RsaUtilities.Rsa4096ModulusLength, decoded4096);
-            CollectionAssert.AreEqual(rawRsa4096, decoded4096);
+            Assert.AreSequenceEqual(rawRsa4096, decoded4096);
         }
 
 
@@ -166,14 +166,14 @@ namespace Verifiable.Tests.Cryptography
 
                 var encodedModulus = RsaUtilities.Encode(rsaModulus);
                 var decodedModulus = RsaUtilities.Decode(encodedModulus);
-                CollectionAssert.AreEqual(rsaModulus, decodedModulus);
+                Assert.AreSequenceEqual(rsaModulus, decodedModulus);
 
                 //This is a bit of extra to show how to get the DER encoded public key from the platform.
                 var dotNetEncoded = ExportPublicKeyAsDerEncoded(rsaKey);
                 var dotNetDecoded = DecodeDerPublicKey(dotNetEncoded);
-                CollectionAssert.AreEqual(encodedModulus, dotNetEncoded);
-                CollectionAssert.AreEqual(rsaParameters.Modulus, dotNetDecoded.Modulus);
-                CollectionAssert.AreEqual(rsaParameters.Exponent, dotNetDecoded.Exponent);
+                Assert.AreSequenceEqual(encodedModulus, dotNetEncoded);
+                Assert.AreSequenceEqual(rsaParameters.Modulus, dotNetDecoded.Modulus);
+                Assert.AreSequenceEqual(rsaParameters.Exponent, dotNetDecoded.Exponent);
             }
         }
 

--- a/test/Verifiable.Tests/Cryptography/SignatureTests.cs
+++ b/test/Verifiable.Tests/Cryptography/SignatureTests.cs
@@ -128,7 +128,7 @@ internal sealed class SignatureTests
 
         ReadOnlySpan<byte> span = sig;
 
-        Assert.AreEqual(SignatureBytes1.Length, span.Length);
+        Assert.HasCount(SignatureBytes1.Length, span);
         Assert.IsTrue(span.SequenceEqual(SignatureBytes1), "Implicit span conversion should preserve all bytes.");
     }
 

--- a/test/Verifiable.Tests/Cryptography/SymmetricKeyMemoryTests.cs
+++ b/test/Verifiable.Tests/Cryptography/SymmetricKeyMemoryTests.cs
@@ -63,6 +63,6 @@ internal sealed class SymmetricKeyMemoryTests
             static (bytes, _) => ValueTask.FromResult(bytes.ToArray()),
             0).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(expected, observed);
+        Assert.AreSequenceEqual(expected, observed);
     }
 }

--- a/test/Verifiable.Tests/DataIntegrity/Bbs2023SpecVectorTests.cs
+++ b/test/Verifiable.Tests/DataIntegrity/Bbs2023SpecVectorTests.cs
@@ -286,8 +286,8 @@ internal sealed class Bbs2023W3cVectorTests
             Assert.AreEqual(b, actual, $"Derived label for '{c14n}' must match W3C Example 25.");
         }
 
-        CollectionAssert.AreEqual(DerivedMandatoryIndexes, derivedProof.MandatoryIndexes.ToArray(), "Adjusted mandatory indexes must match W3C Example 24/25.");
-        CollectionAssert.AreEqual(DerivedSelectiveIndexes, derivedProof.SelectiveIndexes.ToArray(), "Adjusted selective indexes must match W3C Example 24/25.");
+        Assert.AreSequenceEqual(DerivedMandatoryIndexes, derivedProof.MandatoryIndexes.ToArray(), "Adjusted mandatory indexes must match W3C Example 24/25.");
+        Assert.AreSequenceEqual(DerivedSelectiveIndexes, derivedProof.SelectiveIndexes.ToArray(), "Adjusted selective indexes must match W3C Example 24/25.");
 
         //The serialized derived proof has the same structure and length as W3C Example 26, and its
         //randomness-independent tail (the CBOR-encoded label map, mandatory/selective indexes, and

--- a/test/Verifiable.Tests/DidComm/DidCommOutOfBandInvitationTests.cs
+++ b/test/Verifiable.Tests/DidComm/DidCommOutOfBandInvitationTests.cs
@@ -96,7 +96,7 @@ internal sealed class DidCommOutOfBandInvitationTests
         Assert.AreEqual(invitation.From, result.Invitation.From);
         Assert.AreEqual("issue-vc", result.Invitation.GetOutOfBandGoalCode());
         Assert.AreEqual("To issue a Faber College Graduate credential", result.Invitation.GetOutOfBandGoal());
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new List<string> { "didcomm/v2", "didcomm/aip2;env=rfc587" },
             new List<string>(result.Invitation.GetOutOfBandAccept()));
     }

--- a/test/Verifiable.Tests/DidComm/DidCommPlaintextMessageTests.cs
+++ b/test/Verifiable.Tests/DidComm/DidCommPlaintextMessageTests.cs
@@ -86,7 +86,7 @@ internal sealed class DidCommPlaintextMessageTests
         Assert.AreEqual(message.Id, roundTripped.Id);
         Assert.AreEqual(message.Type, roundTripped.Type);
         Assert.AreEqual(message.From, roundTripped.From);
-        CollectionAssert.AreEqual((List<string>)message.To!, (List<string>)roundTripped.To!);
+        Assert.AreSequenceEqual((List<string>)message.To!, (List<string>)roundTripped.To!);
         Assert.AreEqual(message.ThreadId, roundTripped.ThreadId);
         Assert.AreEqual(message.ParentThreadId, roundTripped.ParentThreadId);
         Assert.AreEqual(message.CreatedTime, roundTripped.CreatedTime);

--- a/test/Verifiable.Tests/Federation/FederationEffectiveMetadataResolverTests.cs
+++ b/test/Verifiable.Tests/Federation/FederationEffectiveMetadataResolverTests.cs
@@ -327,7 +327,7 @@ internal sealed class FederationEffectiveMetadataResolverTests
         Assert.IsNotNull(result);
         Assert.IsTrue(result.IsSuccess, result.FailureReason);
         List<object> grantTypes = (List<object>)result.EffectiveMetadata!["grant_types"];
-        CollectionAssert.AreEquivalent(ExpectedOverriddenGrantTypes, grantTypes);
+        Assert.AreSequenceEqual(ExpectedOverriddenGrantTypes, grantTypes, SequenceOrder.InAnyOrder);
     }
 
 
@@ -374,7 +374,7 @@ internal sealed class FederationEffectiveMetadataResolverTests
         Assert.IsNotNull(result);
         Assert.IsTrue(result.IsSuccess, result.FailureReason);
         List<object> grantTypes = (List<object>)result.EffectiveMetadata!["grant_types"];
-        CollectionAssert.AreEqual(ExpectedTrimmedToAuthCode, grantTypes);
+        Assert.AreSequenceEqual(ExpectedTrimmedToAuthCode, grantTypes);
     }
 
 

--- a/test/Verifiable.Tests/Federation/MetadataPolicyApplicatorTests.cs
+++ b/test/Verifiable.Tests/Federation/MetadataPolicyApplicatorTests.cs
@@ -65,7 +65,7 @@ internal sealed class MetadataPolicyApplicatorTests
 
         Assert.IsTrue(result.IsSuccess);
         List<object> scope = (List<object>)result.EffectiveMetadata!["scope"];
-        CollectionAssert.AreEquivalent(ExpectedAddedScope, scope);
+        Assert.AreSequenceEqual(ExpectedAddedScope, scope, SequenceOrder.InAnyOrder);
     }
 
 
@@ -80,7 +80,7 @@ internal sealed class MetadataPolicyApplicatorTests
 
         Assert.IsTrue(result.IsSuccess);
         List<object> scope = (List<object>)result.EffectiveMetadata!["scope"];
-        CollectionAssert.AreEquivalent(ExpectedDefaultScope, scope);
+        Assert.AreSequenceEqual(ExpectedDefaultScope, scope, SequenceOrder.InAnyOrder);
     }
 
 
@@ -137,7 +137,7 @@ internal sealed class MetadataPolicyApplicatorTests
 
         Assert.IsTrue(result.IsSuccess);
         List<object> grantTypes = (List<object>)result.EffectiveMetadata!["grant_types"];
-        CollectionAssert.AreEqual(ExpectedTrimmedGrantTypes, grantTypes);
+        Assert.AreSequenceEqual(ExpectedTrimmedGrantTypes, grantTypes);
     }
 
 

--- a/test/Verifiable.Tests/Federation/MetadataPolicyMergerTests.cs
+++ b/test/Verifiable.Tests/Federation/MetadataPolicyMergerTests.cs
@@ -61,7 +61,7 @@ internal sealed class MetadataPolicyMergerTests
         Assert.IsTrue(result.IsSuccess);
         ParameterPolicy merged = result.MergedBlock!.ParameterPolicies["scope"];
         List<object> subsetOf = (List<object>)merged.Operators[WellKnownMetadataPolicyOperators.SubsetOf];
-        CollectionAssert.AreEquivalent(ProfileEmail, subsetOf);
+        Assert.AreSequenceEqual(ProfileEmail, subsetOf, SequenceOrder.InAnyOrder);
     }
 
 
@@ -101,7 +101,7 @@ internal sealed class MetadataPolicyMergerTests
         Assert.IsTrue(result.IsSuccess);
         ParameterPolicy merged = result.MergedBlock!.ParameterPolicies["scope"];
         List<object> add = (List<object>)merged.Operators[WellKnownMetadataPolicyOperators.Add];
-        CollectionAssert.AreEquivalent(OpenIdProfile, add);
+        Assert.AreSequenceEqual(OpenIdProfile, add, SequenceOrder.InAnyOrder);
     }
 
 

--- a/test/Verifiable.Tests/Federation/TrustChainResolverTests.cs
+++ b/test/Verifiable.Tests/Federation/TrustChainResolverTests.cs
@@ -113,7 +113,7 @@ internal sealed class TrustChainResolverTests
 
         Assert.IsNotNull(chain, "The walker must assemble a chain to the trust anchor.");
         Assert.HasCount(5, chain!, "leaf EC, SS, intermediate EC, SS, anchor EC.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[]
             {
                 leafEc.CompactJws,

--- a/test/Verifiable.Tests/Fido2/AttestationObjectCborWriterTests.cs
+++ b/test/Verifiable.Tests/Fido2/AttestationObjectCborWriterTests.cs
@@ -70,7 +70,7 @@ internal sealed class AttestationObjectCborWriterTests
         AttestationObjectParts parts = AttestationObjectCborReader.Parse(written.Memory);
 
         Assert.AreEqual(WellKnownWebAuthnAttestationFormats.None, parts.Format);
-        Assert.AreEqual(1, parts.AttestationStatement.Length);
+        Assert.HasCount(1, parts.AttestationStatement);
         Assert.AreEqual(NoneAttestation.CanonicalEmptyMap, parts.AttestationStatement.Span[0]);
     }
 

--- a/test/Verifiable.Tests/Fido2/AuthenticatorDataReaderTests.cs
+++ b/test/Verifiable.Tests/Fido2/AuthenticatorDataReaderTests.cs
@@ -39,7 +39,7 @@ internal sealed class AuthenticatorDataReaderTests
         Assert.AreEqual((byte)0x00, parsed.Flags.Value);
         Assert.AreEqual(16909060u, parsed.SignCount);
         Assert.IsNull(parsed.AttestedCredentialData);
-        Assert.AreEqual(0, parsed.Extensions.Length);
+        Assert.HasCount(0, parsed.Extensions);
     }
 
 
@@ -67,7 +67,7 @@ internal sealed class AuthenticatorDataReaderTests
         Assert.IsTrue(parsed.AttestedCredentialData.CredentialId.AsReadOnlySpan().SequenceEqual(credentialId));
         Assert.AreEqual(CoseKeyTypes.Ec2, parsed.AttestedCredentialData.CredentialPublicKey.Kty);
         Assert.AreEqual(CoseKeyCurves.P256, parsed.AttestedCredentialData.CredentialPublicKey.Curve);
-        Assert.AreEqual(0, parsed.Extensions.Length);
+        Assert.HasCount(0, parsed.Extensions);
     }
 
 

--- a/test/Verifiable.Tests/Fido2/AuthenticatorDataWriterTests.cs
+++ b/test/Verifiable.Tests/Fido2/AuthenticatorDataWriterTests.cs
@@ -115,7 +115,7 @@ internal sealed class AuthenticatorDataWriterTests
         Assert.IsTrue(parsed.AttestedCredentialData.CredentialId.AsReadOnlySpan().SequenceEqual(credentialId.AsReadOnlySpan()));
         Assert.AreEqual(CoseKeyTypes.Ec2, parsed.AttestedCredentialData.CredentialPublicKey.Kty);
         Assert.AreEqual(CoseKeyCurves.P256, parsed.AttestedCredentialData.CredentialPublicKey.Curve);
-        Assert.AreEqual(0, parsed.Extensions.Length);
+        Assert.HasCount(0, parsed.Extensions);
     }
 
 
@@ -135,7 +135,7 @@ internal sealed class AuthenticatorDataWriterTests
         Assert.IsTrue(parsed.RpIdHash.AsReadOnlySpan().SequenceEqual(rpIdHash.AsReadOnlySpan()));
         Assert.AreEqual(0u, parsed.SignCount);
         Assert.IsNull(parsed.AttestedCredentialData);
-        Assert.AreEqual(0, parsed.Extensions.Length);
+        Assert.HasCount(0, parsed.Extensions);
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorBioEnrollmentTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorBioEnrollmentTests.cs
@@ -450,7 +450,7 @@ internal sealed class CtapAuthenticatorBioEnrollmentTests
 
         CtapBioEnrollmentResponse decoded = CtapBioEnrollmentResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
         Assert.IsNotNull(decoded.TemplateId);
-        Assert.AreEqual(16, decoded.TemplateId!.Value.Length);
+        Assert.HasCount(16, decoded.TemplateId!.Value);
         Assert.AreEqual(WellKnownCtapLastEnrollSampleStatuses.Good, decoded.LastEnrollSampleStatus);
         Assert.AreEqual(CtapAuthenticatorState.MaxCaptureSamplesRequiredForEnroll - 1, decoded.RemainingSamples);
     }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorCapstoneFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorCapstoneFlowTests.cs
@@ -376,7 +376,7 @@ internal sealed class CtapAuthenticatorCapstoneFlowTests
         Assert.AreEqual(2, firstResponse.NumberOfCredentials);
         Assert.IsNull(firstResponse.UserSelected);
         Assert.IsNotNull(firstResponse.User);
-        CollectionAssert.AreEqual(newerUserId, firstResponse.User!.Id.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(newerUserId, firstResponse.User!.Id.AsReadOnlySpan().ToArray());
         Assert.IsNull(firstResponse.User.Name);
         Assert.IsNull(firstResponse.User.DisplayName);
 
@@ -389,7 +389,7 @@ internal sealed class CtapAuthenticatorCapstoneFlowTests
         Assert.IsNull(nextResponse.NumberOfCredentials);
         Assert.IsNull(nextResponse.UserSelected);
         Assert.IsNotNull(nextResponse.User);
-        CollectionAssert.AreEqual(olderUserId, nextResponse.User!.Id.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(olderUserId, nextResponse.User!.Id.AsReadOnlySpan().ToArray());
         Assert.IsNull(nextResponse.User.Name);
         Assert.IsNull(nextResponse.User.DisplayName);
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorChangePinTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorChangePinTests.cs
@@ -392,7 +392,7 @@ internal sealed class CtapAuthenticatorChangePinTests
         CtapAuthenticatorState postChangeState = trace.Received[^1].StateAfter;
         CtapPinUvAuthTokenState currentProtocolOneToken = postChangeState.ProtocolOneToken;
 
-        CollectionAssert.AreNotEqual(
+        Assert.AreNotSequenceEqual(
             issuedToken, currentProtocolOneToken.Token.AsReadOnlySpan().ToArray(),
             "changePIN must mint a fresh protocol-one token, distinct from the one issued before the change.");
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorClientPinFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorClientPinFlowTests.cs
@@ -171,7 +171,7 @@ internal sealed class CtapAuthenticatorClientPinFlowTests
         byte[] secondToken = await freshTokenSession.DecryptTokenAsync(freshTokenResponse.PinUvAuthToken!.Value, TestContext.CancellationToken);
 
         Assert.HasCount(32, secondToken);
-        CollectionAssert.AreNotEqual(firstToken, secondToken, "the token issued before changePIN must be invalidated by the PIN change.");
+        Assert.AreNotSequenceEqual(firstToken, secondToken, "the token issued before changePIN must be invalidated by the PIN change.");
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorConfigTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorConfigTests.cs
@@ -223,7 +223,7 @@ internal sealed class CtapAuthenticatorConfigTests
         Array.Fill(expectedMessage, (byte)0xff, 0, 32);
         expectedMessage[32] = WellKnownCtapCommands.AuthenticatorConfig;
         expectedMessage[33] = (byte)WellKnownCtapAuthenticatorConfigSubCommands.EnableEnterpriseAttestation;
-        CollectionAssert.AreEqual(expectedMessage, message, "the verify message must be exactly 32x0xff || 0x0D || 0x01 with no subCommandParams segment.");
+        Assert.AreSequenceEqual(expectedMessage, message, "the verify message must be exactly 32x0xff || 0x0D || 0x01 with no subCommandParams segment.");
 
         byte[] param = await CtapWaveConfigFixtures.ComputeSignatureAsync(token, protocolId, message, pool, TestContext.CancellationToken);
         var request = new CtapAuthenticatorConfigRequest(

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorCredentialManagementTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorCredentialManagementTests.cs
@@ -551,7 +551,7 @@ internal sealed class CtapAuthenticatorCredentialManagementTests
         CtapCredentialManagementResponse begin = CtapCredentialManagementResponseCborReader.Read(beginResponse.AsReadOnlyMemory()[1..], pool);
         Assert.AreEqual(rpB, begin.Rp!.Id);
         Assert.AreEqual(2, begin.TotalRps);
-        CollectionAssert.AreEqual(ComputeRpIdHashOracle(rpB).ToArray(), begin.RpIdHash!.Value.ToArray());
+        Assert.AreSequenceEqual(ComputeRpIdHashOracle(rpB).ToArray(), begin.RpIdHash!.Value.ToArray());
 
         var nextRequest = new CtapCredentialManagementRequest(SubCommand: WellKnownCtapCredentialManagementSubCommands.EnumerateRpsGetNextRp);
         using PooledMemory nextResponse = await SendCredentialManagementAsync(simulator, nextRequest, pool, TestContext.CancellationToken);
@@ -559,7 +559,7 @@ internal sealed class CtapAuthenticatorCredentialManagementTests
         CtapCredentialManagementResponse next = CtapCredentialManagementResponseCborReader.Read(nextResponse.AsReadOnlyMemory()[1..], pool);
         Assert.AreEqual(rpA, next.Rp!.Id);
         Assert.IsNull(next.TotalRps, "enumerateRPsGetNextRP never reports totalRPs.");
-        CollectionAssert.AreEqual(ComputeRpIdHashOracle(rpA).ToArray(), next.RpIdHash!.Value.ToArray());
+        Assert.AreSequenceEqual(ComputeRpIdHashOracle(rpA).ToArray(), next.RpIdHash!.Value.ToArray());
     }
 
 
@@ -620,8 +620,8 @@ internal sealed class CtapAuthenticatorCredentialManagementTests
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, beginResponse.AsReadOnlySpan()[0]);
         CtapCredentialManagementResponse begin = CtapCredentialManagementResponseCborReader.Read(beginResponse.AsReadOnlyMemory()[1..], pool);
         Assert.AreEqual(2, begin.TotalCredentials);
-        CollectionAssert.AreEqual(firstUserId, begin.User!.Id.AsReadOnlySpan().ToArray());
-        CollectionAssert.AreEqual(first.CredentialId.AsReadOnlySpan().ToArray(), begin.CredentialId!.Id.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(firstUserId, begin.User!.Id.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(first.CredentialId.AsReadOnlySpan().ToArray(), begin.CredentialId!.Id.AsReadOnlySpan().ToArray());
         Assert.AreEqual(first.PublicKey, begin.PublicKey);
         begin.CredentialId.Id.Dispose();
         begin.User.Id.Dispose();
@@ -631,7 +631,7 @@ internal sealed class CtapAuthenticatorCredentialManagementTests
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, nextResponse.AsReadOnlySpan()[0]);
         CtapCredentialManagementResponse next = CtapCredentialManagementResponseCborReader.Read(nextResponse.AsReadOnlyMemory()[1..], pool);
         Assert.IsNull(next.TotalCredentials, "enumerateCredentialsGetNextCredential never reports totalCredentials.");
-        CollectionAssert.AreEqual(secondUserId, next.User!.Id.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(secondUserId, next.User!.Id.AsReadOnlySpan().ToArray());
         Assert.AreEqual(second.PublicKey, next.PublicKey);
         next.CredentialId!.Id.Dispose();
         next.User.Id.Dispose();
@@ -667,7 +667,7 @@ internal sealed class CtapAuthenticatorCredentialManagementTests
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, beginResponse.AsReadOnlySpan()[0]);
 
         List<int> keys = ReadTopLevelIntegerKeys(beginResponse.AsReadOnlyMemory()[1..]);
-        CollectionAssert.DoesNotContain(keys, WellKnownCtapCredentialManagementResponseKeys.ThirdPartyPayment);
+        Assert.DoesNotContain(WellKnownCtapCredentialManagementResponseKeys.ThirdPartyPayment, keys);
 
         using CredentialId disposeId = CredentialId.Create(credentialIdBytes, pool);
     }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorExtensionsTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorExtensionsTests.cs
@@ -182,7 +182,7 @@ internal sealed class CtapAuthenticatorExtensionsTests
         using AuthenticatorData authenticatorData = AuthenticatorDataReader.Read(decoded.AuthData, CredentialPublicKeyCborReader.Read, pool);
 
         Assert.IsFalse(authenticatorData.Flags.ExtensionDataIncluded);
-        Assert.AreEqual(0, authenticatorData.Extensions.Length);
+        Assert.HasCount(0, authenticatorData.Extensions);
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetAssertionClientTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetAssertionClientTests.cs
@@ -52,9 +52,9 @@ internal sealed class CtapAuthenticatorGetAssertionClientTests
         CtapGetAssertionResponse decoded = await CtapAuthenticatorGetAssertionClient.GetAssertionAsync(
             Transceive, CtapGetAssertionRequestCborWriter.Write, request, CtapGetAssertionResponseCborReader.Read, pool, TestContext.CancellationToken);
 
-        CollectionAssert.AreEqual(expectedRequestBytes, capturedRequest);
-        CollectionAssert.AreEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
-        CollectionAssert.AreEqual(scriptedResponse.Signature.ToArray(), decoded.Signature.ToArray());
+        Assert.AreSequenceEqual(expectedRequestBytes, capturedRequest);
+        Assert.AreSequenceEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
+        Assert.AreSequenceEqual(scriptedResponse.Signature.ToArray(), decoded.Signature.ToArray());
 
         CtapWave2AuthenticatorFixtures.DisposeGetAssertionRequest(request);
         credentialId.Dispose();

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetAssertionTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetAssertionTests.cs
@@ -88,7 +88,7 @@ internal sealed class CtapAuthenticatorGetAssertionTests
         try
         {
             Assert.IsNotNull(decoded.User);
-            CollectionAssert.AreEqual(userId, decoded.User!.Id.AsReadOnlySpan().ToArray());
+            Assert.AreSequenceEqual(userId, decoded.User!.Id.AsReadOnlySpan().ToArray());
             Assert.IsNull(decoded.User.Name);
             Assert.IsNull(decoded.User.DisplayName);
         }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetInfoClientTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetInfoClientTests.cs
@@ -40,7 +40,7 @@ internal sealed class CtapAuthenticatorGetInfoClientTests
         CtapGetInfoResponse decoded = await CtapAuthenticatorGetInfoClient.GetInfoAsync(
             Transceive, CtapGetInfoResponseCborReader.Read, BaseMemoryPool.Shared, TestContext.CancellationToken);
 
-        CollectionAssert.AreEqual(new byte[] { WellKnownCtapCommands.GetInfo }, capturedRequest);
+        Assert.AreSequenceEqual(new byte[] { WellKnownCtapCommands.GetInfo }, capturedRequest);
         Assert.AreEqual(aaguid, decoded.Aaguid);
         Assert.AreEqual(WellKnownCtapVersions.Fido23, decoded.Versions[0]);
     }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetInfoFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetInfoFlowTests.cs
@@ -115,10 +115,10 @@ internal sealed class CtapAuthenticatorGetInfoFlowTests
         Guid expectedAaguid = new(expectedAaguidBytes, bigEndian: true);
 
         Assert.AreEqual(expectedAaguid, response.Aaguid);
-        CollectionAssert.AreEqual(new[] { WellKnownCtapVersions.Fido23 }, (ICollection)new List<string>(response.Versions));
+        Assert.AreSequenceEqual(new[] { WellKnownCtapVersions.Fido23 }, (ICollection)new List<string>(response.Versions));
         Assert.IsNotNull(response.Extensions);
         Assert.HasCount(supportedExtensions.Count, response.Extensions!);
-        CollectionAssert.AreEqual(supportedExtensions, new List<string>(response.Extensions!));
+        Assert.AreSequenceEqual(supportedExtensions, new List<string>(response.Extensions!));
         Assert.IsNotNull(response.Options);
         Assert.IsTrue(response.Options!.ResidentKey);
     }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetNextAssertionClientTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetNextAssertionClientTests.cs
@@ -51,9 +51,9 @@ internal sealed class CtapAuthenticatorGetNextAssertionClientTests
         CtapGetAssertionResponse decoded = await CtapAuthenticatorGetNextAssertionClient.GetNextAssertionAsync(
             Transceive, CtapGetAssertionResponseCborReader.Read, pool, TestContext.CancellationToken);
 
-        CollectionAssert.AreEqual(new byte[] { WellKnownCtapCommands.GetNextAssertion }, capturedRequest);
-        CollectionAssert.AreEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
-        CollectionAssert.AreEqual(scriptedResponse.Signature.ToArray(), decoded.Signature.ToArray());
+        Assert.AreSequenceEqual(new byte[] { WellKnownCtapCommands.GetNextAssertion }, capturedRequest);
+        Assert.AreSequenceEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
+        Assert.AreSequenceEqual(scriptedResponse.Signature.ToArray(), decoded.Signature.ToArray());
 
         credentialId.Dispose();
         decoded.Credential.Id.Dispose();

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetNextAssertionTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorGetNextAssertionTests.cs
@@ -58,7 +58,7 @@ internal sealed class CtapAuthenticatorGetNextAssertionTests
             Assert.AreEqual(2, decoded.NumberOfCredentials);
             Assert.IsNull(decoded.UserSelected);
             Assert.IsNotNull(decoded.User);
-            CollectionAssert.AreEqual(newerUserId, decoded.User!.Id.AsReadOnlySpan().ToArray());
+            Assert.AreSequenceEqual(newerUserId, decoded.User!.Id.AsReadOnlySpan().ToArray());
             Assert.IsNull(decoded.User.Name);
             Assert.IsNull(decoded.User.DisplayName);
         }
@@ -101,7 +101,7 @@ internal sealed class CtapAuthenticatorGetNextAssertionTests
             Assert.IsNull(decoded.NumberOfCredentials);
             Assert.IsNull(decoded.UserSelected);
             Assert.IsNotNull(decoded.User);
-            CollectionAssert.AreEqual(olderUserId, decoded.User!.Id.AsReadOnlySpan().ToArray());
+            Assert.AreSequenceEqual(olderUserId, decoded.User!.Id.AsReadOnlySpan().ToArray());
             Assert.IsNull(decoded.User.Name);
             Assert.IsNull(decoded.User.DisplayName);
         }
@@ -135,15 +135,15 @@ internal sealed class CtapAuthenticatorGetNextAssertionTests
         CtapGetAssertionRequest request = BuildGetAssertionRequest(pool);
         byte[] userIdFromFirstResponse = ReadAndDisposeUserId(
             await SendGetAssertionAsync(simulator, request, pool, TestContext.CancellationToken), pool);
-        CollectionAssert.AreEqual(thirdUserId, userIdFromFirstResponse);
+        Assert.AreSequenceEqual(thirdUserId, userIdFromFirstResponse);
 
         byte[] userIdFromSecondResponse = ReadAndDisposeUserId(
             await SendGetNextAssertionAsync(simulator, pool, TestContext.CancellationToken), pool);
-        CollectionAssert.AreEqual(secondUserId, userIdFromSecondResponse);
+        Assert.AreSequenceEqual(secondUserId, userIdFromSecondResponse);
 
         byte[] userIdFromThirdResponse = ReadAndDisposeUserId(
             await SendGetNextAssertionAsync(simulator, pool, TestContext.CancellationToken), pool);
-        CollectionAssert.AreEqual(firstUserId, userIdFromThirdResponse);
+        Assert.AreSequenceEqual(firstUserId, userIdFromThirdResponse);
     }
 
 
@@ -417,7 +417,7 @@ internal sealed class CtapAuthenticatorGetNextAssertionTests
 
         byte[] userIdFromNext = ReadAndDisposeUserId(
             await SendGetNextAssertionAsync(simulator, pool, TestContext.CancellationToken), pool);
-        CollectionAssert.AreEqual(secondRpOlderUserId, userIdFromNext, "authenticatorGetNextAssertion must walk the SECOND (replacing) relying party's sequence.");
+        Assert.AreSequenceEqual(secondRpOlderUserId, userIdFromNext, "authenticatorGetNextAssertion must walk the SECOND (replacing) relying party's sequence.");
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretCapstoneTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretCapstoneTests.cs
@@ -74,7 +74,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
 
         CtapGetInfoResponse getInfoResponse = await CtapAuthenticatorGetInfoClient.GetInfoAsync(
             harness.Transceive, CtapGetInfoResponseCborReader.Read, pool, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[]
             {
                 WellKnownWebAuthnExtensionIdentifiers.CredProtect,
@@ -136,7 +136,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
         (byte[] twoSaltOutput, _) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, credentialIdBytes, twoSaltExtensions, protocolTwoSession, cancellationToken).ConfigureAwait(false);
         Assert.HasCount(64, twoSaltOutput, "a two-salt hmac-secret output decrypts to exactly 64 bytes, on the wire.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             nonUvOutput, twoSaltOutput[..32],
             "R14(c) linkage: a two-salt output's first 32 bytes must equal the one-salt output for the same salt1.");
 
@@ -147,7 +147,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
             determinismSession.PlatformPublicKeyCose, determinismSaltEnc, determinismSaltAuth, pinUvAuthProtocol: null);
         (byte[] determinismOutput, _) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, credentialIdBytes, determinismExtensions, determinismSession, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             nonUvOutput, determinismOutput, "R14(a) determinism: the same salt and uv posture must decrypt to the identical output every time.");
 
         byte[] uvToken = await IssueTokenAsync(harness, pool, CtapPinUvAuthProtocolId.Two, WellKnownCtapPinUvAuthTokenPermissions.Ga, RpId, cancellationToken).ConfigureAwait(false);
@@ -161,7 +161,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
         (byte[] uvOutput, _) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, credentialIdBytes, uvExtensions, uvSession, cancellationToken,
             gaParam: gaParam, gaProtocolId: CtapPinUvAuthProtocolId.Two).ConfigureAwait(false);
-        CollectionAssert.AreNotEqual(
+        Assert.AreNotSequenceEqual(
             nonUvOutput, uvOutput, "R14(b) uv-separation (trap 4): uv=0 and uv=1 must select different CredRandom values for the same salt.");
 
         byte[] secondCredentialIdBytes = await RegisterHmacSecretCredentialAsync(
@@ -173,7 +173,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
             isolationSession.PlatformPublicKeyCose, isolationSaltEnc, isolationSaltAuth, pinUvAuthProtocol: null);
         (byte[] isolationOutput, _) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, secondCredentialIdBytes, isolationExtensions, isolationSession, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreNotEqual(
+        Assert.AreNotSequenceEqual(
             nonUvOutput, isolationOutput,
             "R14(d) credential isolation (trap 21): the same salt against two different credentials must decrypt to different outputs.");
 
@@ -186,10 +186,10 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
             harness, pool, RpId, credentialIdBytes, ivExtensions, ivSession, cancellationToken).ConfigureAwait(false);
         (byte[] secondIvDecrypted, byte[] secondIvCiphertext) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, credentialIdBytes, ivExtensions, ivSession, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreNotEqual(
+        Assert.AreNotSequenceEqual(
             firstIvCiphertext, secondIvCiphertext,
             "R14(e) protocol-two IV freshness (trap 6): two identical protocol-two requests must produce different wire ciphertext bytes.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             firstIvDecrypted, secondIvDecrypted, "R14(e): both requests must decrypt to the identical output despite the different ciphertext.");
 
         using CtapWave5bPlatformPinSession tamperedSession = await CtapWave5bPinCryptoFixtures.EstablishSessionAsync(
@@ -295,7 +295,7 @@ internal sealed class CtapAuthenticatorHmacSecretCapstoneTests
         (byte[] gaDecrypted, _) = await SendHmacSecretGetAssertionAsync(
             harness, pool, RpId, credentialIdBytes, gaExtensions, gaSession, cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             mcDecrypted, gaDecrypted,
             "the mc-time hmac-secret-mc output and a later ga hmac-secret call for the same salt and (non-uv) posture must decrypt to the identical output, on the wire.");
     }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretCredRandomStateTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretCredRandomStateTests.cs
@@ -69,8 +69,8 @@ internal sealed class CtapAuthenticatorHmacSecretCredRandomStateTests
         string credentialIdHex = Convert.ToHexStringLower(credentialIdBytes);
         CtapCredentialRecord record = trace.Received[^1].StateAfter.CredentialsByCredentialId[credentialIdHex];
 
-        Assert.AreEqual(32, record.CredRandomWithUV.Memory.Length);
-        Assert.AreEqual(32, record.CredRandomWithoutUV.Memory.Length);
+        Assert.HasCount(32, record.CredRandomWithUV.Memory);
+        Assert.HasCount(32, record.CredRandomWithoutUV.Memory);
         Assert.IsFalse(
             record.CredRandomWithUV.Memory.Span.SequenceEqual(record.CredRandomWithoutUV.Memory.Span),
             "CredRandomWithUV and CredRandomWithoutUV must be two independently random values, never the same content.");

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretGetAssertionFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretGetAssertionFlowTests.cs
@@ -354,7 +354,7 @@ internal sealed class CtapAuthenticatorHmacSecretGetAssertionFlowTests
         byte[] secondOutput = await RunOneSaltHmacSecretAsync(
             simulator, pool, RpId, CtapWave5AuthenticatorFixtures.BuildAllowList(credentialIdBytes, pool), cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(firstOutput, secondOutput, "the same credential, salt, and uv posture must decrypt to the identical output every time.");
+        Assert.AreSequenceEqual(firstOutput, secondOutput, "the same credential, salt, and uv posture must decrypt to the identical output every time.");
     }
 
 
@@ -391,7 +391,7 @@ internal sealed class CtapAuthenticatorHmacSecretGetAssertionFlowTests
         byte[] nonUvOutput = await RunOneSaltHmacSecretAsync(
             simulator, pool, RpId, CtapWave5AuthenticatorFixtures.BuildAllowList(credentialIdBytes, pool), cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreNotEqual(nonUvOutput, uvOutput, "uv=0 and uv=1 must select different CredRandom values, producing different outputs.");
+        Assert.AreNotSequenceEqual(nonUvOutput, uvOutput, "uv=0 and uv=1 must select different CredRandom values, producing different outputs.");
     }
 
 
@@ -424,7 +424,7 @@ internal sealed class CtapAuthenticatorHmacSecretGetAssertionFlowTests
             CtapWave2AuthenticatorFixtures.BuildFixedBytes(32, 0x66), cancellationToken).ConfigureAwait(false);
 
         byte[] twoSaltFirstHalf = twoSaltOutput[..32];
-        CollectionAssert.AreEqual(oneSaltOutput, twoSaltFirstHalf, "a two-salt output's first 32 bytes must equal the one-salt output for the same salt1.");
+        Assert.AreSequenceEqual(oneSaltOutput, twoSaltFirstHalf, "a two-salt output's first 32 bytes must equal the one-salt output for the same salt1.");
     }
 
 
@@ -450,7 +450,7 @@ internal sealed class CtapAuthenticatorHmacSecretGetAssertionFlowTests
         byte[] secondOutput = await RunOneSaltHmacSecretAsync(
             simulator, pool, RpId, CtapWave5AuthenticatorFixtures.BuildAllowList(secondCredentialIdBytes, pool), cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreNotEqual(firstOutput, secondOutput, "the same salt against two different credentials must decrypt to different outputs.");
+        Assert.AreNotSequenceEqual(firstOutput, secondOutput, "the same salt against two different credentials must decrypt to different outputs.");
     }
 
 
@@ -481,8 +481,8 @@ internal sealed class CtapAuthenticatorHmacSecretGetAssertionFlowTests
         (byte[] secondCiphertext, byte[] secondDecrypted) = await SendAndCaptureCiphertextAsync(
             simulator, pool, RpId, CtapWave5AuthenticatorFixtures.BuildAllowList(credentialIdBytes, pool), extensions, session, cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreNotEqual(firstCiphertext, secondCiphertext, "two identical protocol-two requests must produce different wire ciphertext (fresh IV per call).");
-        CollectionAssert.AreEqual(firstDecrypted, secondDecrypted, "both requests must decrypt to the identical output despite the different ciphertext.");
+        Assert.AreNotSequenceEqual(firstCiphertext, secondCiphertext, "two identical protocol-two requests must produce different wire ciphertext (fresh IV per call).");
+        Assert.AreSequenceEqual(firstDecrypted, secondDecrypted, "both requests must decrypt to the identical output despite the different ciphertext.");
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretMcFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorHmacSecretMcFlowTests.cs
@@ -173,7 +173,7 @@ internal sealed class CtapAuthenticatorHmacSecretMcFlowTests
         byte[] gaCiphertext = DecodeCborByteString(FindExtensionOutput(gaOutputs, WellKnownWebAuthnExtensionIdentifiers.HmacSecret));
         byte[] gaDecrypted = await gaSession.DecryptHmacSecretOutputAsync(gaCiphertext, cancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(mcDecrypted, gaDecrypted,
+        Assert.AreSequenceEqual(mcDecrypted, gaDecrypted,
             "the mc-time hmac-secret-mc output and a later ga hmac-secret call for the same salt and (non-uv) posture must decrypt to the identical HMAC output.");
     }
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobKeyExtensionTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobKeyExtensionTests.cs
@@ -48,7 +48,7 @@ internal sealed class CtapAuthenticatorLargeBlobKeyExtensionTests
         CtapMakeCredentialResponse decoded = CtapMakeCredentialResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
 
         Assert.IsNotNull(decoded.LargeBlobKey);
-        Assert.AreEqual(32, decoded.LargeBlobKey!.Value.Length);
+        Assert.HasCount(32, decoded.LargeBlobKey!.Value);
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobsFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobsFlowTests.cs
@@ -69,7 +69,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
         (byte freshStatus, CtapLargeBlobsResponse? freshResponse) = await SendGetAsync(
             harness.Transceive, pool, CtapAuthenticatorState.InitialSerializedLargeBlobArray.Length, offset: 0, cancellationToken).ConfigureAwait(false);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, freshStatus);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), freshResponse!.Config.ToArray(),
             "a fresh authenticator's get must return the 17-byte initial constant byte-exactly, on the wire.");
 
@@ -97,7 +97,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, thirdStatus, "the third and final fragment must commit the whole write.");
 
         byte[] readBack = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreEqual(fullArray, readBack, "the read-back array must byte-exactly match the committed write.");
+        Assert.AreSequenceEqual(fullArray, readBack, "the read-back array must byte-exactly match the committed write.");
 
         byte throwawayFirstStatus = await CtapWaveLargeBlobPlatformFixtures.SendFragmentAsync(
             harness.Transceive, pool, new byte[] { 0x01, 0x02 }, offset: 0, length: 50, token: null, ProtocolId, cancellationToken).ConfigureAwait(false);
@@ -113,7 +113,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackAfterDiscard = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             fullArray, readBackAfterDiscard, "the abandoned throwaway sequence must never have overwritten the previously committed array.");
     }
 
@@ -150,7 +150,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackAfterLbwWrite = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(firstEntry, readBackAfterLbwWrite, "the lbw-token-driven write must land on the wire exactly as sent.");
+        Assert.AreSequenceEqual(firstEntry, readBackAfterLbwWrite, "the lbw-token-driven write must land on the wire exactly as sent.");
 
         byte[] mcClientDataHash = CtapWave2AuthenticatorFixtures.BuildFixedBytes(32, 0x10);
         byte[] mcParam = await CtapWaveConfigFixtures.ComputeSignatureAsync(token, ProtocolId, mcClientDataHash, pool, cancellationToken).ConfigureAwait(false);
@@ -171,7 +171,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackAfterCarveOut = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             secondEntry, readBackAfterCarveOut,
             "the SAME token -- stripped of mc but still carrying lbw (the line 5828 carve-out) -- must still drive a full set to completion, on the wire.");
     }
@@ -238,7 +238,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] recovered = await CtapWaveLargeBlobPlatformFixtures.ReadAndDecryptEntryAsync(harness.Transceive, pool, largeBlobKey, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(opaqueData, recovered, "the real DEFLATE+AES-256-GCM round trip must recover the exact original opaque payload.");
+        Assert.AreSequenceEqual(opaqueData, recovered, "the real DEFLATE+AES-256-GCM round trip must recover the exact original opaque payload.");
 
         await EstablishPinAsync(harness.Transceive, pool, ProtocolId, Pin, cancellationToken).ConfigureAwait(false);
         byte[] cmToken = await IssueTokenAsync(
@@ -276,7 +276,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackBeforeReset = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(committed, readBackBeforeReset);
+        Assert.AreSequenceEqual(committed, readBackBeforeReset);
 
         byte[] resetRequest = [WellKnownCtapCommands.Reset];
         using(PooledMemory resetResponse = await harness.Transceive(resetRequest, pool, cancellationToken).ConfigureAwait(false))
@@ -287,7 +287,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
         (byte postResetStatus, CtapLargeBlobsResponse? postResetResponse) = await SendGetAsync(
             harness.Transceive, pool, CtapAuthenticatorState.InitialSerializedLargeBlobArray.Length, offset: 0, cancellationToken).ConfigureAwait(false);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, postResetStatus);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), postResetResponse!.Config.ToArray(),
             "authenticatorReset must restore the initial serialized large-blob array byte-exactly, on the wire.");
 
@@ -303,7 +303,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackAfterCycle = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), readBackAfterCycle,
             "the power cycle must preserve the reset-restored constant, discarding only the abandoned pending write.");
     }
@@ -337,7 +337,7 @@ internal sealed class CtapAuthenticatorLargeBlobsFlowTests
 
         byte[] readBackAfterFailure = await CtapWaveLargeBlobPlatformFixtures.ReadEntireSerializedArrayAsync(harness.Transceive, pool, cancellationToken)
             .ConfigureAwait(false);
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             committed, readBackAfterFailure, "a commit-time integrity failure must leave the previously stored array byte-exact and unchanged, on the wire.");
     }
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobsTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorLargeBlobsTests.cs
@@ -45,7 +45,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
 
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, response.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
-        CollectionAssert.AreEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
+        Assert.AreSequenceEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
     }
 
 
@@ -65,7 +65,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
 
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, response.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
-        Assert.AreEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.Length, decoded.Config.Length);
+        Assert.HasCount(CtapAuthenticatorState.InitialSerializedLargeBlobArray.Length, decoded.Config);
     }
 
 
@@ -84,7 +84,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
 
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, response.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
-        Assert.AreEqual(0, decoded.Config.Length);
+        Assert.HasCount(0, decoded.Config);
     }
 
 
@@ -104,7 +104,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
 
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, response.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
-        Assert.AreEqual(0, decoded.Config.Length);
+        Assert.HasCount(0, decoded.Config);
     }
 
 
@@ -658,7 +658,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
         using PooledMemory getResponse = await SendLargeBlobsAsync(simulator, getRequest, pool, TestContext.CancellationToken);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, getResponse.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(getResponse.AsReadOnlyMemory()[1..]);
-        CollectionAssert.AreEqual(fullArray, decoded.Config.ToArray());
+        Assert.AreSequenceEqual(fullArray, decoded.Config.ToArray());
     }
 
 
@@ -680,7 +680,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
         using PooledMemory getResponse = await SendLargeBlobsAsync(simulator, getRequest, pool, TestContext.CancellationToken);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, getResponse.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(getResponse.AsReadOnlyMemory()[1..]);
-        CollectionAssert.AreEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
+        Assert.AreSequenceEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
     }
 
 
@@ -719,7 +719,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
         using PooledMemory getResponse = await SendLargeBlobsAsync(simulator, getRequest, pool, TestContext.CancellationToken);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, getResponse.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(getResponse.AsReadOnlyMemory()[1..]);
-        CollectionAssert.AreEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
+        Assert.AreSequenceEqual(CtapAuthenticatorState.InitialSerializedLargeBlobArray.ToArray(), decoded.Config.ToArray());
     }
 
 
@@ -790,7 +790,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
         using PooledMemory getResponse = await SendLargeBlobsAsync(simulator, getRequest, pool, TestContext.CancellationToken);
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, getResponse.AsReadOnlySpan()[0]);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(getResponse.AsReadOnlyMemory()[1..]);
-        CollectionAssert.AreEqual(committed, decoded.Config.ToArray(), "the previously committed array must survive the power cycle untouched.");
+        Assert.AreSequenceEqual(committed, decoded.Config.ToArray(), "the previously committed array must survive the power cycle untouched.");
     }
 
 
@@ -958,7 +958,7 @@ internal sealed class CtapAuthenticatorLargeBlobsTests
         ];
         using(DigestValue actualDigest = CryptographicKeyEvents.ComputeDigest(fragment, 32, CryptoTags.Sha256Digest, pool))
         {
-            CollectionAssert.AreEqual(expectedSha256OfAbc, actualDigest.AsReadOnlySpan().ToArray(), "SHA-256(\"abc\") must match the well-known NIST test vector, hand-verified independently of this KAT's own offset encoding.");
+            Assert.AreSequenceEqual(expectedSha256OfAbc, actualDigest.AsReadOnlySpan().ToArray(), "SHA-256(\"abc\") must match the well-known NIST test vector, hand-verified independently of this KAT's own offset encoding.");
         }
 
         using CtapAuthenticatorSimulator correctSimulator = CreateSimulator("largeblobs-kat-correct");

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialClientTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialClientTests.cs
@@ -52,9 +52,9 @@ internal sealed class CtapAuthenticatorMakeCredentialClientTests
         CtapMakeCredentialResponse decoded = await CtapAuthenticatorMakeCredentialClient.MakeCredentialAsync(
             Transceive, CtapMakeCredentialRequestCborWriter.Write, request, CtapMakeCredentialResponseCborReader.Read, pool, TestContext.CancellationToken);
 
-        CollectionAssert.AreEqual(expectedRequestBytes, capturedRequest);
+        Assert.AreSequenceEqual(expectedRequestBytes, capturedRequest);
         Assert.AreEqual(WellKnownWebAuthnAttestationFormats.None, decoded.Fmt);
-        CollectionAssert.AreEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
+        Assert.AreSequenceEqual(scriptedResponse.AuthData.ToArray(), decoded.AuthData.ToArray());
 
         CtapWave2AuthenticatorFixtures.DisposeMakeCredentialRequest(request);
     }
@@ -114,8 +114,8 @@ internal sealed class CtapAuthenticatorMakeCredentialClientTests
         AttestationObjectParts parts = AttestationObjectCborReader.Parse(attestationObject.Memory);
 
         Assert.AreEqual(WellKnownWebAuthnAttestationFormats.None, parts.Format);
-        CollectionAssert.AreEqual(authData, parts.AuthenticatorData.ToArray());
-        Assert.AreEqual(1, parts.AttestationStatement.Length);
+        Assert.AreSequenceEqual(authData, parts.AuthenticatorData.ToArray());
+        Assert.HasCount(1, parts.AttestationStatement);
         Assert.AreEqual(NoneAttestation.CanonicalEmptyMap, parts.AttestationStatement.Span[0]);
     }
 
@@ -138,8 +138,8 @@ internal sealed class CtapAuthenticatorMakeCredentialClientTests
         AttestationObjectParts parts = AttestationObjectCborReader.Parse(attestationObject.Memory);
 
         Assert.AreEqual(WellKnownWebAuthnAttestationFormats.None, parts.Format);
-        CollectionAssert.AreEqual(authData, parts.AuthenticatorData.ToArray());
-        Assert.AreEqual(1, parts.AttestationStatement.Length);
+        Assert.AreSequenceEqual(authData, parts.AuthenticatorData.ToArray());
+        Assert.HasCount(1, parts.AttestationStatement);
         Assert.AreEqual(NoneAttestation.CanonicalEmptyMap, parts.AttestationStatement.Span[0]);
     }
 }

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialEnterpriseAttestationTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialEnterpriseAttestationTests.cs
@@ -159,7 +159,7 @@ internal sealed class CtapAuthenticatorMakeCredentialEnterpriseAttestationTests
                 Assert.AreEqual(WellKnownCoseAlgorithms.Es256, statement.Alg);
                 Assert.IsNotNull(statement.X5c, "a certified mint must carry x5c.");
                 Assert.HasCount(1, statement.X5c!);
-                CollectionAssert.AreEqual(
+                Assert.AreSequenceEqual(
                     provisioning.X5c[0].AsReadOnlySpan().ToArray(), statement.X5c![0].AsReadOnlySpan().ToArray(),
                     "the wire x5c entry must be the seeded chain's own bytes, verbatim.");
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorMakeCredentialTests.cs
@@ -55,7 +55,7 @@ internal sealed class CtapAuthenticatorMakeCredentialTests
         //Independent oracle: rpIdHash computed here via the framework SHA-256 API, not the production
         //ComputeDigest seam the simulator itself used.
         byte[] expectedRpIdHash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(DefaultRpId));
-        CollectionAssert.AreEqual(expectedRpIdHash, authenticatorData.RpIdHash.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(expectedRpIdHash, authenticatorData.RpIdHash.AsReadOnlySpan().ToArray());
 
         Assert.IsTrue(authenticatorData.Flags.UserPresent);
         Assert.IsFalse(authenticatorData.Flags.UserVerified);
@@ -298,7 +298,7 @@ internal sealed class CtapAuthenticatorMakeCredentialTests
         byte[] firstCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, BuildFixedBytes(16, 0x91), TestContext.CancellationToken);
         byte[] secondCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, BuildFixedBytes(16, 0x92), TestContext.CancellationToken);
 
-        CollectionAssert.AreNotEqual(firstCredentialId, secondCredentialId);
+        Assert.AreNotSequenceEqual(firstCredentialId, secondCredentialId);
     }
 
 
@@ -317,7 +317,7 @@ internal sealed class CtapAuthenticatorMakeCredentialTests
         byte[] firstCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, userId, TestContext.CancellationToken);
         byte[] secondCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, userId, TestContext.CancellationToken);
 
-        CollectionAssert.AreNotEqual(firstCredentialId, secondCredentialId);
+        Assert.AreNotSequenceEqual(firstCredentialId, secondCredentialId);
     }
 
 
@@ -337,7 +337,7 @@ internal sealed class CtapAuthenticatorMakeCredentialTests
         byte[] firstCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, userId, TestContext.CancellationToken);
         byte[] secondCredentialId = await RegisterAndCaptureCredentialIdBytesAsync(simulator, pool, userId, TestContext.CancellationToken);
 
-        CollectionAssert.AreNotEqual(firstCredentialId, secondCredentialId);
+        Assert.AreNotSequenceEqual(firstCredentialId, secondCredentialId);
 
         CtapMakeCredentialRequest thirdRequest = BuildMakeCredentialRequest(
             pool,

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorPackedAttestationTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorPackedAttestationTests.cs
@@ -136,7 +136,7 @@ internal sealed class CtapAuthenticatorPackedAttestationTests
         CtapMakeCredentialResponse decoded = CtapMakeCredentialResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
         Assert.AreEqual(WellKnownWebAuthnAttestationFormats.None, decoded.Fmt);
         Assert.IsTrue(decoded.AttStmt.HasValue, "A multi-entry preference resolving to none must still carry the standard empty-map attStmt.");
-        Assert.AreEqual(1, decoded.AttStmt!.Value.Length);
+        Assert.HasCount(1, decoded.AttStmt!.Value);
         Assert.AreEqual(NoneAttestation.CanonicalEmptyMap, decoded.AttStmt.Value.Span[0]);
     }
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorPinTokenIssuanceTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorPinTokenIssuanceTests.cs
@@ -67,7 +67,7 @@ internal sealed class CtapAuthenticatorPinTokenIssuanceTests
         CtapClientPinResponse response = await SendAsync(simulator, request, pool);
 
         Assert.IsNotNull(response.PinUvAuthToken);
-        Assert.AreEqual(expectedCiphertextLength, response.PinUvAuthToken!.Value.Length);
+        Assert.HasCount(expectedCiphertextLength, response.PinUvAuthToken!.Value);
 
         byte[] token = await session.DecryptTokenAsync(response.PinUvAuthToken.Value, TestContext.CancellationToken);
         Assert.HasCount(32, token, "the decrypted pinUvAuthToken itself must be 32 bytes for both protocols.");
@@ -739,7 +739,7 @@ internal sealed class CtapAuthenticatorPinTokenIssuanceTests
 
         CtapPinUvAuthTokenState currentProtocolTwoToken = trace.Received[^1].StateAfter.ProtocolTwoToken;
 
-        CollectionAssert.AreNotEqual(
+        Assert.AreNotSequenceEqual(
             firstToken, currentProtocolTwoToken.Token.AsReadOnlySpan().ToArray(),
             "each fresh getPinToken issuance must mint a genuinely new token value.");
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorPowerCycleTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorPowerCycleTests.cs
@@ -85,7 +85,7 @@ internal sealed class CtapAuthenticatorPowerCycleTests
         Assert.IsTrue(after.IsAlwaysUvEnabled, "alwaysUv survives a power cycle; only authenticatorReset reverts it.");
         Assert.AreEqual(6, after.MinPinCodePointLength, "the current minimum PIN length survives a power cycle; only authenticatorReset reverts it.");
         Assert.IsTrue(after.IsForcePinChangeRequired, "forcePINChange survives a power cycle; only authenticatorReset or a successful changePIN clears it.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             (string[])[.. before.MinPinLengthRpIds], (string[])[.. after.MinPinLengthRpIds],
             "minPinLengthRPIDs (§7.4.3 line 8424) survives a power cycle; only authenticatorReset clears it.");
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorResetFlowTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorResetFlowTests.cs
@@ -130,7 +130,7 @@ internal sealed class CtapAuthenticatorResetFlowTests
         }
 
         byte[] postResetGetInfoBytes = await GetInfoBytesAsync(harness.Transceive, pool, cancellationToken).ConfigureAwait(false);
-        CollectionAssert.AreEqual(birthGetInfoBytes, postResetGetInfoBytes, "post-reset getInfo bytes must be byte-identical to the birth capture (R8).");
+        Assert.AreSequenceEqual(birthGetInfoBytes, postResetGetInfoBytes, "post-reset getInfo bytes must be byte-identical to the birth capture (R8).");
 
         Assert.AreEqual(
             CtapAuthenticatorState.MaxPinRetries, await GetPinRetriesAsync(harness.Transceive, pool, cancellationToken).ConfigureAwait(false),

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorResetTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorResetTests.cs
@@ -374,7 +374,7 @@ internal sealed class CtapAuthenticatorResetTests
 
         ReadOnlySpan<byte> initialLargeBlobArray = CtapAuthenticatorState.InitialSerializedLargeBlobArray;
         Assert.AreEqual(initialLargeBlobArray.Length, after.SerializedLargeBlobArray.Length, "line 7541: the initial serialized large-blob array is 17 bytes.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             initialLargeBlobArray.ToArray(), after.SerializedLargeBlobArray.AsReadOnlySpan().ToArray(),
             "line 7705's MUST + line 6336: FactoryReset restores the initial serialized large-blob array byte string, byte-exact, even though `before` carried a grown (40-byte) array.");
 
@@ -389,10 +389,10 @@ internal sealed class CtapAuthenticatorResetTests
         Assert.AreSame(before.ProtocolTwoKeyAgreementKeyPair, after.ProtocolTwoKeyAgreementKeyPair);
         Assert.AreSame(before.ProtocolOneToken, after.ProtocolOneToken);
         Assert.AreSame(before.ProtocolTwoToken, after.ProtocolTwoToken);
-        CollectionAssert.AreEqual(protocolOneKeyBefore, after.ProtocolOneKeyAgreementKeyPair.PublicKey.AsReadOnlySpan().ToArray());
-        CollectionAssert.AreEqual(protocolTwoKeyBefore, after.ProtocolTwoKeyAgreementKeyPair.PublicKey.AsReadOnlySpan().ToArray());
-        CollectionAssert.AreEqual(protocolOneTokenBefore, after.ProtocolOneToken.Token.AsReadOnlySpan().ToArray());
-        CollectionAssert.AreEqual(protocolTwoTokenBefore, after.ProtocolTwoToken.Token.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(protocolOneKeyBefore, after.ProtocolOneKeyAgreementKeyPair.PublicKey.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(protocolTwoKeyBefore, after.ProtocolTwoKeyAgreementKeyPair.PublicKey.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(protocolOneTokenBefore, after.ProtocolOneToken.Token.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(protocolTwoTokenBefore, after.ProtocolTwoToken.Token.AsReadOnlySpan().ToArray());
 
         after.ProtocolOneKeyAgreementKeyPair.Dispose();
         after.ProtocolTwoKeyAgreementKeyPair.Dispose();
@@ -520,7 +520,7 @@ internal sealed class CtapAuthenticatorResetTests
 
         using PooledMemory postReset = await simulator.TransceiveAsync(getInfoRequest, pool, TestContext.CancellationToken);
 
-        CollectionAssert.AreEqual(birthBytes, postReset.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(birthBytes, postReset.AsReadOnlySpan().ToArray());
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorSimulatorTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorSimulatorTests.cs
@@ -76,7 +76,7 @@ internal sealed class CtapAuthenticatorSimulatorTests
         Assert.AreEqual(WellKnownCtapStatusCodes.Ok, response.AsReadOnlySpan()[0]);
 
         CtapGetInfoResponse decoded = CtapGetInfoResponseCborReader.Read(response.AsReadOnlyMemory()[1..]);
-        CollectionAssert.Contains(new List<string>(decoded.Versions), WellKnownCtapVersions.Fido23);
+        Assert.Contains(WellKnownCtapVersions.Fido23, new List<string>(decoded.Versions));
         Assert.AreEqual(expectedAaguid, decoded.Aaguid);
         Assert.IsNotNull(decoded.Options);
         Assert.IsTrue(decoded.Options!.ResidentKey);

--- a/test/Verifiable.Tests/Fido2/CtapAuthenticatorTransitionsTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapAuthenticatorTransitionsTests.cs
@@ -90,7 +90,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         await automaton.StepAsync(new GetInfoRequested(), TestContext.CancellationToken);
 
         var intent = (GetInfoResponseReady)automaton.CurrentState.ResponseIntent!;
-        CollectionAssert.AreEqual(extensions, new List<string>(intent.Response.Extensions!));
+        Assert.AreSequenceEqual(extensions, new List<string>(intent.Response.Extensions!));
     }
 
 
@@ -108,7 +108,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         await automaton.StepAsync(new GetInfoRequested(), TestContext.CancellationToken);
 
         var intent = (GetInfoResponseReady)automaton.CurrentState.ResponseIntent!;
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new List<string>
             {
                 WellKnownWebAuthnExtensionIdentifiers.CredProtect,
@@ -140,7 +140,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         Assert.IsFalse(intent.Response.Options!.ClientPin);
         Assert.IsTrue(intent.Response.Options.PinUvAuthToken);
         Assert.IsNotNull(intent.Response.PinUvAuthProtocols);
-        CollectionAssert.AreEqual(new List<int> { 2, 1 }, new List<int>(intent.Response.PinUvAuthProtocols!));
+        Assert.AreSequenceEqual(new List<int> { 2, 1 }, new List<int>(intent.Response.PinUvAuthProtocols!));
     }
 
 
@@ -185,7 +185,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         Assert.IsFalse(intent.Response.ForcePinChange);
         Assert.AreEqual(CtapAuthenticatorState.MaxRpIdsForSetMinPinLengthCapacity, intent.Response.MaxRpIdsForSetMinPinLength);
         Assert.AreEqual(initialState.ResidentCredentialCapacity, intent.Response.RemainingDiscoverableCredentials);
-        CollectionAssert.AreEqual(new List<int> { 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
+        Assert.AreSequenceEqual(new List<int> { 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
     }
 
 
@@ -208,7 +208,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         var intent = (GetInfoResponseReady)automaton.CurrentState.ResponseIntent!;
         Assert.IsNotNull(intent.Response.Options);
         Assert.IsNull(intent.Response.Options!.Ep, "ep must be absent for a non-capable authenticator.");
-        CollectionAssert.AreEqual(new List<int> { 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
+        Assert.AreSequenceEqual(new List<int> { 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
     }
 
 
@@ -241,7 +241,7 @@ internal sealed class CtapAuthenticatorTransitionsTests
         Assert.IsNotNull(intent.Response.Options);
         Assert.IsNotNull(intent.Response.Options!.Ep, "ep must be present for a capable authenticator.");
         Assert.AreEqual(isEnterpriseAttestationEnabled, intent.Response.Options.Ep!.Value);
-        CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
+        Assert.AreSequenceEqual(new List<int> { 1, 2, 3 }, new List<int>(intent.Response.AuthenticatorConfigCommands!));
 
         provisioning.Dispose();
     }

--- a/test/Verifiable.Tests/Fido2/CtapClientPinRequestCborReaderTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapClientPinRequestCborReaderTests.cs
@@ -80,9 +80,9 @@ internal sealed class CtapClientPinRequestCborReaderTests
         Assert.AreEqual(CoseKeyTypes.Ec2, decoded.KeyAgreement!.Kty);
         Assert.AreEqual(-25, decoded.KeyAgreement.Alg);
         Assert.AreEqual(CoseKeyCurves.P256, decoded.KeyAgreement.Curve);
-        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03 }, decoded.PinUvAuthParam!.Value.ToArray());
-        CollectionAssert.AreEqual(new byte[] { 0x04, 0x05 }, decoded.NewPinEnc!.Value.ToArray());
-        CollectionAssert.AreEqual(new byte[] { 0x06 }, decoded.PinHashEnc!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x01, 0x02, 0x03 }, decoded.PinUvAuthParam!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x04, 0x05 }, decoded.NewPinEnc!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x06 }, decoded.PinHashEnc!.Value.ToArray());
         Assert.AreEqual(written.Permissions, decoded.Permissions);
         Assert.AreEqual(written.RpId, decoded.RpId);
     }

--- a/test/Verifiable.Tests/Fido2/CtapClientPinResponseCborReaderTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapClientPinResponseCborReaderTests.cs
@@ -62,7 +62,7 @@ internal sealed class CtapClientPinResponseCborReaderTests
         Assert.AreEqual(CoseKeyTypes.Ec2, decoded.KeyAgreement!.Kty);
         Assert.AreEqual(-25, decoded.KeyAgreement.Alg);
         Assert.AreEqual(CoseKeyCurves.P256, decoded.KeyAgreement.Curve);
-        CollectionAssert.AreEqual(new byte[] { 0xAA, 0xBB }, decoded.PinUvAuthToken!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0xAA, 0xBB }, decoded.PinUvAuthToken!.Value.ToArray());
         Assert.AreEqual(7, decoded.PinRetries);
         Assert.IsFalse(decoded.PowerCycleState!.Value);
         Assert.AreEqual(3, decoded.UvRetries);

--- a/test/Verifiable.Tests/Fido2/CtapCommandEntityCborCodecTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapCommandEntityCborCodecTests.cs
@@ -149,7 +149,7 @@ internal sealed class CtapCommandEntityCborCodecTests
             new CborReader(userWriter.Encode(), CborConformanceMode.Ctap2Canonical), BaseMemoryPool.Shared);
         try
         {
-            Assert.AreEqual(3, user.Id.AsReadOnlySpan().Length);
+            Assert.HasCount(3, user.Id.AsReadOnlySpan());
         }
         finally
         {

--- a/test/Verifiable.Tests/Fido2/CtapGetInfoResponseCborReaderTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapGetInfoResponseCborReaderTests.cs
@@ -47,9 +47,9 @@ internal sealed class CtapGetInfoResponseCborReaderTests
         TaggedMemory<byte> encoded = CtapGetInfoResponseCborWriter.Write(written);
         CtapGetInfoResponse decoded = CtapGetInfoResponseCborReader.Read(encoded.Memory);
 
-        CollectionAssert.AreEqual(new List<string>(written.Versions), new List<string>(decoded.Versions));
+        Assert.AreSequenceEqual(new List<string>(written.Versions), new List<string>(decoded.Versions));
         Assert.AreEqual(aaguid, decoded.Aaguid);
-        CollectionAssert.AreEqual(new List<string>(written.Extensions!), new List<string>(decoded.Extensions!));
+        Assert.AreSequenceEqual(new List<string>(written.Extensions!), new List<string>(decoded.Extensions!));
         Assert.IsNotNull(decoded.Options);
         Assert.IsTrue(decoded.Options!.ResidentKey!.Value);
         Assert.IsFalse(decoded.Options!.Platform!.Value);
@@ -140,7 +140,7 @@ internal sealed class CtapGetInfoResponseCborReaderTests
         Assert.IsTrue(decoded.Options.PinUvAuthToken!.Value);
         Assert.IsTrue(decoded.Options.MakeCredUvNotRqd!.Value);
         Assert.IsNotNull(decoded.PinUvAuthProtocols);
-        CollectionAssert.AreEqual(new List<int> { 2, 1 }, new List<int>(decoded.PinUvAuthProtocols!));
+        Assert.AreSequenceEqual(new List<int> { 2, 1 }, new List<int>(decoded.PinUvAuthProtocols!));
     }
 
 
@@ -192,7 +192,7 @@ internal sealed class CtapGetInfoResponseCborReaderTests
         Assert.AreEqual(isAlwaysUvEnabled ? 6 : 4, decoded.MinPinLength!.Value);
         Assert.AreEqual(0, decoded.MaxRpIdsForSetMinPinLength!.Value);
         Assert.AreEqual(8, decoded.RemainingDiscoverableCredentials!.Value);
-        CollectionAssert.AreEqual(new List<int> { 2, 3 }, new List<int>(decoded.AuthenticatorConfigCommands!));
+        Assert.AreSequenceEqual(new List<int> { 2, 3 }, new List<int>(decoded.AuthenticatorConfigCommands!));
     }
 
 
@@ -257,7 +257,7 @@ internal sealed class CtapGetInfoResponseCborReaderTests
         Assert.IsNotNull(decoded.Options);
         Assert.AreEqual(isEnterpriseAttestationEnabled, decoded.Options!.Ep!.Value);
         Assert.IsTrue(decoded.Options!.ResidentKey!.Value);
-        CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, new List<int>(decoded.AuthenticatorConfigCommands!));
+        Assert.AreSequenceEqual(new List<int> { 1, 2, 3 }, new List<int>(decoded.AuthenticatorConfigCommands!));
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapLargeBlobsRequestCborReaderTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapLargeBlobsRequestCborReaderTests.cs
@@ -70,10 +70,10 @@ internal sealed class CtapLargeBlobsRequestCborReaderTests
         CtapLargeBlobsRequest decoded = CtapLargeBlobsRequestCborReader.Read(encoded.Memory);
 
         Assert.AreEqual(written.Get, decoded.Get);
-        CollectionAssert.AreEqual(new byte[] { 0xAA, 0xBB, 0xCC }, decoded.Set!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0xAA, 0xBB, 0xCC }, decoded.Set!.Value.ToArray());
         Assert.AreEqual(written.Offset, decoded.Offset);
         Assert.AreEqual(written.Length, decoded.Length);
-        CollectionAssert.AreEqual(new byte[] { 0x11, 0x22, 0x33 }, decoded.PinUvAuthParam!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x11, 0x22, 0x33 }, decoded.PinUvAuthParam!.Value.ToArray());
         Assert.AreEqual(written.PinUvAuthProtocol, decoded.PinUvAuthProtocol);
     }
 
@@ -98,7 +98,7 @@ internal sealed class CtapLargeBlobsRequestCborReaderTests
         Assert.IsTrue(encoded.Span.SequenceEqual(expected));
 
         CtapLargeBlobsRequest decoded = CtapLargeBlobsRequestCborReader.Read(encoded.Memory);
-        CollectionAssert.AreEqual(new byte[] { 0x11, 0x22, 0x33 }, decoded.PinUvAuthParam!.Value.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x11, 0x22, 0x33 }, decoded.PinUvAuthParam!.Value.ToArray());
         Assert.AreEqual(2, decoded.PinUvAuthProtocol);
     }
 

--- a/test/Verifiable.Tests/Fido2/CtapLargeBlobsResponseCborWriterTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapLargeBlobsResponseCborWriterTests.cs
@@ -60,7 +60,7 @@ internal sealed class CtapLargeBlobsResponseCborWriterTests
         TaggedMemory<byte> encoded = CtapLargeBlobsResponseCborWriter.Write(written);
         CtapLargeBlobsResponse decoded = CtapLargeBlobsResponseCborReader.Read(encoded.Memory);
 
-        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 }, decoded.Config.ToArray());
+        Assert.AreSequenceEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 }, decoded.Config.ToArray());
     }
 
 

--- a/test/Verifiable.Tests/Fido2/CtapPinUvAuthProtocolTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapPinUvAuthProtocolTests.cs
@@ -279,7 +279,7 @@ internal sealed class CtapPinUvAuthProtocolTests
         using DecryptedContent decrypted = await protocol.DecryptAsync(
             key, ciphertext.AsReadOnlyMemory(), BaseMemoryPool.Shared, TestContext.CancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(plaintext, decrypted.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(plaintext, decrypted.AsReadOnlySpan().ToArray());
     }
 
     /// <summary>
@@ -323,7 +323,7 @@ internal sealed class CtapPinUvAuthProtocolTests
         using DecryptedContent decrypted = await protocol.DecryptAsync(
             key, ciphertext.AsReadOnlyMemory(), BaseMemoryPool.Shared, TestContext.CancellationToken).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(plaintext, decrypted.AsReadOnlySpan().ToArray());
+        Assert.AreSequenceEqual(plaintext, decrypted.AsReadOnlySpan().ToArray());
     }
 
     /// <summary>CTAP 2.3 §6.5.7 line 6250-6261: protocol two's <c>decrypt</c> must reject ciphertext shorter than the 16-byte prefixed IV.</summary>

--- a/test/Verifiable.Tests/Fido2/CtapPinUvAuthTokenStateTests.cs
+++ b/test/Verifiable.Tests/Fido2/CtapPinUvAuthTokenStateTests.cs
@@ -27,7 +27,7 @@ internal sealed class CtapPinUvAuthTokenStateTests
     {
         using CtapPinUvAuthTokenState state = CtapPinUvAuthTokenState.Initial(BaseMemoryPool.Shared);
 
-        Assert.AreEqual(TokenLength, state.Token.AsReadOnlySpan().Length, "The pinUvAuthToken must be 32 bytes for both PIN/UV auth protocols.");
+        Assert.HasCount(TokenLength, state.Token.AsReadOnlySpan(), "The pinUvAuthToken must be 32 bytes for both PIN/UV auth protocols.");
         Assert.IsNull(state.PermissionsRpId, "The permissions RP ID is initially null (line 5019).");
         Assert.AreEqual(0, state.Permissions, "The permissions set is initially empty (line 5021).");
         Assert.IsFalse(state.IsInUse, "The in use flag is initially false (line 5026).");
@@ -58,7 +58,7 @@ internal sealed class CtapPinUvAuthTokenStateTests
 
         using CtapPinUvAuthTokenState reset = mutated.ResetToken(BaseMemoryPool.Shared);
 
-        Assert.AreEqual(TokenLength, reset.Token.AsReadOnlySpan().Length);
+        Assert.HasCount(TokenLength, reset.Token.AsReadOnlySpan());
         Assert.IsFalse(originalTokenBytes.AsSpan().SequenceEqual(reset.Token.AsReadOnlySpan()), "resetPinUvAuthToken() must mint a NEW random token value, not reuse the old bytes.");
         Assert.IsNull(reset.PermissionsRpId);
         Assert.AreEqual(0, reset.Permissions);

--- a/test/Verifiable.Tests/Fido2/Fido2CoseRfcVectorTests.cs
+++ b/test/Verifiable.Tests/Fido2/Fido2CoseRfcVectorTests.cs
@@ -97,8 +97,8 @@ internal sealed class Fido2CoseRfcVectorTests
     {
         (byte[] x, byte[] y) = DeriveEcPublicKeyCoordinates(Es256PrivateScalarBase64Url, "secp256r1");
 
-        CollectionAssert.AreEqual(DecodeBase64Url(Es256PublicXBase64Url), x);
-        CollectionAssert.AreEqual(DecodeBase64Url(Es256PublicYBase64Url), y);
+        Assert.AreSequenceEqual(DecodeBase64Url(Es256PublicXBase64Url), x);
+        Assert.AreSequenceEqual(DecodeBase64Url(Es256PublicYBase64Url), y);
     }
 
 
@@ -111,8 +111,8 @@ internal sealed class Fido2CoseRfcVectorTests
     {
         (byte[] x, byte[] y) = DeriveEcPublicKeyCoordinates(Es512PrivateScalarBase64Url, "secp521r1");
 
-        CollectionAssert.AreEqual(DecodeBase64Url(Es512PublicXBase64Url), x);
-        CollectionAssert.AreEqual(DecodeBase64Url(Es512PublicYBase64Url), y);
+        Assert.AreSequenceEqual(DecodeBase64Url(Es512PublicXBase64Url), x);
+        Assert.AreSequenceEqual(DecodeBase64Url(Es512PublicYBase64Url), y);
     }
 
 
@@ -127,7 +127,7 @@ internal sealed class Fido2CoseRfcVectorTests
 
         byte[] derivedPublicKey = DeriveEd25519PublicKey(seed);
 
-        CollectionAssert.AreEqual(DecodeBase64Url(EdDsaPublicKeyBase64Url), derivedPublicKey);
+        Assert.AreSequenceEqual(DecodeBase64Url(EdDsaPublicKeyBase64Url), derivedPublicKey);
     }
 
 

--- a/test/Verifiable.Tests/Fido2/LargeBlobExtensionProcessorTests.cs
+++ b/test/Verifiable.Tests/Fido2/LargeBlobExtensionProcessorTests.cs
@@ -156,7 +156,7 @@ internal sealed class LargeBlobExtensionProcessorTests
         Claim readClaim = GetClaim(result, Fido2ClaimIds.Fido2AssertionLargeBlobRead);
         Assert.AreEqual(ClaimOutcome.Success, readClaim.Outcome);
         var readContext = (LargeBlobReadContext)readClaim.Context;
-        CollectionAssert.AreEqual(blobBytes, readContext.Blob.Span.ToArray());
+        Assert.AreSequenceEqual(blobBytes, readContext.Blob.Span.ToArray());
         Assert.AreEqual(Fido2BufferTags.LargeBlob, readContext.Blob.Tag);
 
         Assert.AreEqual(ClaimOutcome.NotApplicable, GetOutcome(result, Fido2ClaimIds.Fido2AssertionLargeBlobWritten));
@@ -255,7 +255,7 @@ internal sealed class LargeBlobExtensionProcessorTests
 
         Claim readClaim = GetClaim(result, Fido2ClaimIds.Fido2AssertionLargeBlobRead);
         Assert.AreEqual(ClaimOutcome.Success, readClaim.Outcome);
-        CollectionAssert.AreEqual(blobBytes, ((LargeBlobReadContext)readClaim.Context).Blob.Span.ToArray());
+        Assert.AreSequenceEqual(blobBytes, ((LargeBlobReadContext)readClaim.Context).Blob.Span.ToArray());
         Assert.AreEqual(ClaimOutcome.Success, GetOutcome(result, Fido2ClaimIds.Fido2AssertionExtensionOutputs));
     }
 

--- a/test/Verifiable.Tests/Fido2/PackedEnterpriseAttestationTests.cs
+++ b/test/Verifiable.Tests/Fido2/PackedEnterpriseAttestationTests.cs
@@ -141,11 +141,11 @@ internal sealed class PackedEnterpriseAttestationTests
         byte[] decoded = reader.ReadOctetString();
 
         Assert.IsFalse(reader.HasData);
-        CollectionAssert.AreEqual(serialNumber, decoded);
+        Assert.AreSequenceEqual(serialNumber, decoded);
 
         var handWritten = new AsnWriter(AsnEncodingRules.DER);
         handWritten.WriteOctetString(serialNumber);
-        CollectionAssert.AreEqual(handWritten.Encode(), encoded);
+        Assert.AreSequenceEqual(handWritten.Encode(), encoded);
     }
 
 

--- a/test/Verifiable.Tests/Foundation/PooledMemoryTests.cs
+++ b/test/Verifiable.Tests/Foundation/PooledMemoryTests.cs
@@ -47,8 +47,8 @@ internal sealed class PooledMemoryTests
         using PooledMemory pooledMemory = PooledMemory.FromBytes(source, pool, TestTag);
 
         Assert.AreEqual(requestedLength, pooledMemory.Length);
-        Assert.AreEqual(requestedLength, pooledMemory.AsReadOnlySpan().Length);
-        Assert.AreEqual(requestedLength, pooledMemory.AsReadOnlyMemory().Length);
+        Assert.HasCount(requestedLength, pooledMemory.AsReadOnlySpan());
+        Assert.HasCount(requestedLength, pooledMemory.AsReadOnlyMemory());
         Assert.IsTrue(pooledMemory.AsReadOnlySpan().SequenceEqual(source));
     }
 

--- a/test/Verifiable.Tests/JCose/CoseKeyConformanceTests.cs
+++ b/test/Verifiable.Tests/JCose/CoseKeyConformanceTests.cs
@@ -157,8 +157,8 @@ internal sealed class CoseKeyConformanceTests
     {
         int[] expected = [CoseKeyParameters.Kty, CoseKeyParameters.Alg, CoseKeyParameters.Crv, CoseKeyParameters.X, CoseKeyParameters.Y];
 
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Ec2).ToArray());
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Ec2).ToArray());
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Ec2).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Ec2).ToArray(), SequenceOrder.InAnyOrder);
     }
 
 
@@ -168,8 +168,8 @@ internal sealed class CoseKeyConformanceTests
     {
         int[] expected = [CoseKeyParameters.Kty, CoseKeyParameters.Alg, CoseKeyParameters.Crv, CoseKeyParameters.X];
 
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Okp).ToArray());
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Okp).ToArray());
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Okp).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Okp).ToArray(), SequenceOrder.InAnyOrder);
     }
 
 
@@ -179,8 +179,8 @@ internal sealed class CoseKeyConformanceTests
     {
         int[] expected = [CoseKeyParameters.Kty, CoseKeyParameters.Alg, CoseKeyParameters.RsaN, CoseKeyParameters.RsaE];
 
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Rsa).ToArray());
-        CollectionAssert.AreEquivalent(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Rsa).ToArray());
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.RequiredParameterLabels(CoseKeyTypes.Rsa).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(expected, CoseKeyConformance.AllowedParameterLabels(CoseKeyTypes.Rsa).ToArray(), SequenceOrder.InAnyOrder);
     }
 
 

--- a/test/Verifiable.Tests/Jose/JwkThumbprintMalformedInputTests.cs
+++ b/test/Verifiable.Tests/Jose/JwkThumbprintMalformedInputTests.cs
@@ -128,7 +128,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Should compute thumbprint even with invalid encoding since we hash the string as-is per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Should compute thumbprint even with invalid encoding since we hash the string as-is per RFC 7638.");
     }
 
     [TestMethod]
@@ -145,7 +145,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeGenericThumbprint(jwkParams);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Should handle very large parameter values without overflow.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Should handle very large parameter values without overflow.");
     }
 
     [TestMethod]
@@ -162,7 +162,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeGenericThumbprint(jwkParams);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Should handle UTF-8 special characters correctly per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Should handle UTF-8 special characters correctly per RFC 7638.");
     }
 
     [TestMethod]
@@ -175,7 +175,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeMlDsaThumbprint(alg, kty, x);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Thumbprint should compute even with mismatched parameters (garbage in, deterministic garbage out per RFC 7638).");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Thumbprint should compute even with mismatched parameters (garbage in, deterministic garbage out per RFC 7638).");
     }
 
     [TestMethod]
@@ -188,7 +188,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeMlDsaThumbprint(alg, kty, x);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "ML-DSA-44 thumbprint must be 32 bytes per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "ML-DSA-44 thumbprint must be 32 bytes per RFC 7638.");
     }
 
     [TestMethod]
@@ -201,7 +201,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeMlKemThumbprint(alg, kty, x);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "ML-KEM-768 thumbprint must be 32 bytes per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "ML-KEM-768 thumbprint must be 32 bytes per RFC 7638.");
     }
 
     [TestMethod]
@@ -214,7 +214,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeSlhDsaThumbprint(alg, kty, x);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SLH-DSA-128f thumbprint must be 32 bytes per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SLH-DSA-128f thumbprint must be 32 bytes per RFC 7638.");
     }
 
     [TestMethod]
@@ -228,7 +228,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Empty strings should produce valid thumbprint per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Empty strings should produce valid thumbprint per RFC 7638.");
     }
 
     [TestMethod]
@@ -239,7 +239,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeGenericThumbprint(jwkParams);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Single parameter should produce valid thumbprint.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Single parameter should produce valid thumbprint.");
     }
 
     [TestMethod]
@@ -250,7 +250,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeGenericThumbprint(jwkParams);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Different casing should be treated as different keys.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Different casing should be treated as different keys.");
     }
 
     [TestMethod]
@@ -263,7 +263,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeRsaThumbprint(e, kty, n);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Whitespace should be preserved in thumbprint calculation per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Whitespace should be preserved in thumbprint calculation per RFC 7638.");
     }
 
     [TestMethod]
@@ -277,7 +277,7 @@ internal class JwkThumbprintMalformedInputTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "Non-ASCII characters should be UTF-8 encoded per RFC 7638.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "Non-ASCII characters should be UTF-8 encoded per RFC 7638.");
     }
 
     [TestMethod]

--- a/test/Verifiable.Tests/Jose/JwkThumbprintRfcVectorTests.cs
+++ b/test/Verifiable.Tests/Jose/JwkThumbprintRfcVectorTests.cs
@@ -59,7 +59,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeEcdhThumbprint(crv, kty, x);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeECThumbprint(crv, kty, x, y);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeOctThumbprint(k, kty);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>
@@ -144,7 +144,7 @@ internal class JwkThumbprintRfcVectorTests
 
         using var thumbprint = JwkThumbprintUtilities.ComputeGenericThumbprint(jwkParams);
         
-        Assert.AreEqual(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory.Length, "SHA-256 hash must be 32 bytes.");
+        Assert.HasCount(JwkTemplateConstants.Sha256HashSizeInBytes, thumbprint.Memory, "SHA-256 hash must be 32 bytes.");
     }
 
     /// <summary>

--- a/test/Verifiable.Tests/JsonPointer/JsonPointerPropertyTests.cs
+++ b/test/Verifiable.Tests/JsonPointer/JsonPointerPropertyTests.cs
@@ -231,8 +231,12 @@ internal sealed class JsonPointerPropertyTests
     {
         GenPointer.Sample(pointer =>
         {
-            Assert.AreEqual(pointer, pointer);
-            Assert.AreEqual(pointer.GetHashCode(), pointer.GetHashCode());
+            //A distinct, independently parsed instance with the same value exercises the actual
+            //field-by-field comparison instead of trivially passing on reference identity.
+            var samePointer = Ptr.Parse(pointer.ToString());
+
+            Assert.AreEqual(pointer, samePointer);
+            Assert.AreEqual(pointer.GetHashCode(), samePointer.GetHashCode());
         });
     }
 

--- a/test/Verifiable.Tests/JsonPointer/Jsonata/JsonataEvaluatorTests.cs
+++ b/test/Verifiable.Tests/JsonPointer/Jsonata/JsonataEvaluatorTests.cs
@@ -150,7 +150,7 @@ internal sealed class JsonataEvaluatorTests
         IReadOnlyDictionary<string, JsonataValue> members = result.AsObject();
         Assert.AreEqual("urn:1", members["id"].AsString());
         Assert.AreEqual("credential", members["kind"].AsString());
-        CollectionAssert.AreEqual(ExpectedOrderedKeys, members.Keys.ToArray());
+        Assert.AreSequenceEqual(ExpectedOrderedKeys, members.Keys.ToArray());
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriEventCborTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriEventCborTests.cs
@@ -54,9 +54,9 @@ internal sealed class KeriEventCborTests
         Assert.AreEqual(Aid, inception.Prefix);
         Assert.AreEqual(0, inception.SequenceNumber);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.SigningThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriEventCesrTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriEventCesrTests.cs
@@ -191,10 +191,10 @@ internal sealed class KeriEventCesrTests
         Assert.AreEqual("2", fields[KeriMessageFields.KeysSigningThreshold]);
         Assert.AreEqual("2", fields[KeriMessageFields.NextKeysSigningThreshold]);
         Assert.AreEqual("3", fields[KeriMessageFields.BackerThreshold]);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)fields[KeriMessageFields.SigningKeys]!);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)fields[KeriMessageFields.NextKeyDigests]!);
-        CollectionAssert.AreEqual(Backers, (System.Collections.ICollection)fields[KeriMessageFields.Backers]!);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)fields[KeriMessageFields.ConfigurationTraits]!);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)fields[KeriMessageFields.SigningKeys]!);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)fields[KeriMessageFields.NextKeyDigests]!);
+        Assert.AreSequenceEqual(Backers, (System.Collections.ICollection)fields[KeriMessageFields.Backers]!);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)fields[KeriMessageFields.ConfigurationTraits]!);
         Assert.IsEmpty((IReadOnlyList<object?>)fields[KeriMessageFields.Anchors]!);
     }
 
@@ -216,10 +216,10 @@ internal sealed class KeriEventCesrTests
         Assert.AreEqual(0, inception.SequenceNumber);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.SigningThreshold);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.NextThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
-        CollectionAssert.AreEqual(Backers, (System.Collections.ICollection)inception.Backers);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
+        Assert.AreSequenceEqual(Backers, (System.Collections.ICollection)inception.Backers);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
     }
 
 
@@ -285,8 +285,8 @@ internal sealed class KeriEventCesrTests
         Assert.AreEqual("EDmgVuwPOXDjIW3reg4_k8SeJoQEKJKP24fGzeMV4uKD", rotation.PriorSaid);
         Assert.AreEqual(KeriThreshold.Unweighted(2), rotation.SigningThreshold);
         Assert.AreEqual(KeriThreshold.Unweighted(2), rotation.NextThreshold);
-        CollectionAssert.AreEqual(RotationBackersToRemove, (System.Collections.ICollection)rotation.BackersToRemove);
-        CollectionAssert.AreEqual(RotationBackersToAdd, (System.Collections.ICollection)rotation.BackersToAdd);
+        Assert.AreSequenceEqual(RotationBackersToRemove, (System.Collections.ICollection)rotation.BackersToRemove);
+        Assert.AreSequenceEqual(RotationBackersToAdd, (System.Collections.ICollection)rotation.BackersToAdd);
         Assert.IsEmpty((IReadOnlyList<string>)rotation.ConfigurationTraits);
 
         IReadOnlyList<KeriSeal> seals = KeriSealReader.ReadList(fields[KeriMessageFields.Anchors]);
@@ -311,8 +311,8 @@ internal sealed class KeriEventCesrTests
         MessageFieldMap fields = KeriEventCesr.DecodeFieldMap(native.Memory, BaseMemoryPool.Shared);
 
         Assert.AreEqual("KERICAACAACESRAAKM.", fields[KeriMessageFields.Version]);
-        CollectionAssert.AreEqual(WeightedThresholdWeights, (System.Collections.ICollection)fields[KeriMessageFields.KeysSigningThreshold]!);
-        CollectionAssert.AreEqual(WeightedThresholdWeights, (System.Collections.ICollection)fields[KeriMessageFields.NextKeysSigningThreshold]!);
+        Assert.AreSequenceEqual(WeightedThresholdWeights, (System.Collections.ICollection)fields[KeriMessageFields.KeysSigningThreshold]!);
+        Assert.AreSequenceEqual(WeightedThresholdWeights, (System.Collections.ICollection)fields[KeriMessageFields.NextKeysSigningThreshold]!);
 
         var dip = (KeriDelegatedInceptionEvent)KeriEventReader.Read(fields);
         Assert.AreEqual("EF-jViYoBr8p3vkpZuHlkvxAAY5GZkmQ0QaaHfiE0kg3", dip.Said);
@@ -322,8 +322,8 @@ internal sealed class KeriEventCesrTests
         Assert.AreEqual(HalfWeightThreshold, dip.SigningThreshold);
         Assert.AreEqual(HalfWeightThreshold, dip.NextThreshold);
         Assert.IsTrue(dip.SigningThreshold.IsWeighted);
-        CollectionAssert.AreEqual(DelegatedInceptionKeys, (System.Collections.ICollection)dip.SigningKeys);
-        CollectionAssert.AreEqual(DelegatedInceptionBackers, (System.Collections.ICollection)dip.Backers);
+        Assert.AreSequenceEqual(DelegatedInceptionKeys, (System.Collections.ICollection)dip.SigningKeys);
+        Assert.AreSequenceEqual(DelegatedInceptionBackers, (System.Collections.ICollection)dip.Backers);
         Assert.IsEmpty((IReadOnlyList<string>)dip.ConfigurationTraits);
 
         Assert.IsTrue(await KeriEventSaid.VerifyAsync(native.Memory, dip.Said, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None));
@@ -349,9 +349,9 @@ internal sealed class KeriEventCesrTests
         Assert.AreEqual("EF-jViYoBr8p3vkpZuHlkvxAAY5GZkmQ0QaaHfiE0kg3", drt.PriorSaid);
         Assert.AreEqual(HalfWeightThreshold, drt.SigningThreshold);
         Assert.AreEqual(HalfWeightThreshold, drt.NextThreshold);
-        CollectionAssert.AreEqual(DelegatedRotationKeys, (System.Collections.ICollection)drt.SigningKeys);
-        CollectionAssert.AreEqual(DelegatedRotationBackersToRemove, (System.Collections.ICollection)drt.BackersToRemove);
-        CollectionAssert.AreEqual(DelegatedRotationBackersToAdd, (System.Collections.ICollection)drt.BackersToAdd);
+        Assert.AreSequenceEqual(DelegatedRotationKeys, (System.Collections.ICollection)drt.SigningKeys);
+        Assert.AreSequenceEqual(DelegatedRotationBackersToRemove, (System.Collections.ICollection)drt.BackersToRemove);
+        Assert.AreSequenceEqual(DelegatedRotationBackersToAdd, (System.Collections.ICollection)drt.BackersToAdd);
 
         Assert.IsTrue(await KeriEventSaid.VerifyAsync(native.Memory, drt.Said, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None));
     }

--- a/test/Verifiable.Tests/Keri/KeriEventJsonTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriEventJsonTests.cs
@@ -53,9 +53,9 @@ internal sealed class KeriEventJsonTests
         Assert.AreEqual(Aid, inception.Prefix);
         Assert.AreEqual(0, inception.SequenceNumber);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.SigningThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriEventMgpkConformanceTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriEventMgpkConformanceTests.cs
@@ -60,9 +60,9 @@ internal sealed class KeriEventMgpkConformanceTests
         Assert.AreEqual(Aid, inception.Prefix);
         Assert.AreEqual(0, inception.SequenceNumber);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.SigningThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriEventReaderTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriEventReaderTests.cs
@@ -52,9 +52,9 @@ internal sealed class KeriEventReaderTests
         Assert.AreEqual(Aid, inception.Prefix);
         Assert.AreEqual(0, inception.SequenceNumber);
         Assert.AreEqual(KeriThreshold.Unweighted(2), inception.SigningThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)inception.SigningKeys);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)inception.NextKeyDigests);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)inception.ConfigurationTraits);
     }
 
 
@@ -115,8 +115,8 @@ internal sealed class KeriEventReaderTests
 
         Assert.IsInstanceOfType<KeriRotationEvent>(read);
         var rotation = (KeriRotationEvent)read;
-        CollectionAssert.AreEqual(toRemove, (System.Collections.ICollection)rotation.BackersToRemove);
-        CollectionAssert.AreEqual(toAdd, (System.Collections.ICollection)rotation.BackersToAdd);
+        Assert.AreSequenceEqual(toRemove, (System.Collections.ICollection)rotation.BackersToRemove);
+        Assert.AreSequenceEqual(toAdd, (System.Collections.ICollection)rotation.BackersToAdd);
     }
 
 
@@ -232,7 +232,7 @@ internal sealed class KeriEventReaderTests
 
         Assert.AreEqual(Aid, state.Prefix);
         Assert.AreEqual(0, state.SequenceNumber);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)state.SigningKeys);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)state.SigningKeys);
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriKeyEventLogReplayTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriKeyEventLogReplayTests.cs
@@ -79,7 +79,7 @@ internal sealed class KeriKeyEventLogReplayTests
             var rotation = (KeriRotationEvent)entries[2].Operation!;
 
             Assert.AreEqual(2, finalState.SequenceNumber, "The log advances to sequence two.");
-            CollectionAssert.AreEqual((System.Collections.ICollection)rotation.SigningKeys, (System.Collections.ICollection)finalState.SigningKeys, "The final keys are the rotated-in keys.");
+            Assert.AreSequenceEqual((System.Collections.ICollection)rotation.SigningKeys, (System.Collections.ICollection)finalState.SigningKeys, "The final keys are the rotated-in keys.");
             Assert.AreEqual(rotation.Said, finalState.LastEventSaid, "The last event SAID is the rotation's.");
         }
         finally

--- a/test/Verifiable.Tests/Keri/KeriKeyEventStreamTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriKeyEventStreamTests.cs
@@ -79,7 +79,7 @@ internal sealed class KeriKeyEventStreamTests
             Assert.IsNotNull(result.KeyState, "A verified log yields a key state.");
             Assert.AreEqual(2, result.KeyState!.SequenceNumber, "The log advances to sequence two.");
             Assert.AreEqual(rotation.Said, result.KeyState.LastEventSaid, "The last event SAID is the rotation's.");
-            CollectionAssert.AreEqual(
+            Assert.AreSequenceEqual(
                 (System.Collections.ICollection)rotation.SigningKeys,
                 (System.Collections.ICollection)result.KeyState.SigningKeys,
                 "The final keys are the rotation's revealed keys.");

--- a/test/Verifiable.Tests/Keri/KeriKeyStateMachineTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriKeyStateMachineTests.cs
@@ -49,12 +49,12 @@ internal sealed class KeriKeyStateMachineTests
 
         Assert.AreEqual(Aid, state.Prefix);
         Assert.AreEqual(KeriThreshold.Unweighted(2), state.SigningThreshold);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)state.SigningKeys);
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)state.SigningKeys);
         Assert.AreEqual(KeriThreshold.Unweighted(2), state.NextThreshold);
-        CollectionAssert.AreEqual(NextKeyDigests, (System.Collections.ICollection)state.NextKeyDigests);
+        Assert.AreSequenceEqual(NextKeyDigests, (System.Collections.ICollection)state.NextKeyDigests);
         Assert.AreEqual("3", state.BackerThreshold);
         Assert.HasCount(4, state.Backers);
-        CollectionAssert.AreEqual(ConfigurationTraits, (System.Collections.ICollection)state.ConfigurationTraits);
+        Assert.AreSequenceEqual(ConfigurationTraits, (System.Collections.ICollection)state.ConfigurationTraits);
         Assert.AreEqual(0, state.SequenceNumber);
         Assert.AreEqual(Aid, state.LastEventSaid, "The inception SAID becomes the last event SAID the next event chains to.");
     }
@@ -97,8 +97,8 @@ internal sealed class KeriKeyStateMachineTests
 
         Assert.AreEqual(1, advanced.SequenceNumber);
         Assert.AreEqual("EInteractionSaid000000000000000000000000000", advanced.LastEventSaid);
-        CollectionAssert.AreEqual(SigningKeys, (System.Collections.ICollection)advanced.SigningKeys, "An interaction does not change the signing keys.");
-        Assert.AreEqual(inception.NextKeyDigests, advanced.NextKeyDigests, "An interaction does not change the pre-rotation commitments.");
+        Assert.AreSequenceEqual(SigningKeys, (System.Collections.ICollection)advanced.SigningKeys, "An interaction does not change the signing keys.");
+        Assert.AreSequenceEqual(inception.NextKeyDigests, advanced.NextKeyDigests, "An interaction does not change the pre-rotation commitments.");
     }
 
 

--- a/test/Verifiable.Tests/Keri/KeriRotationTests.cs
+++ b/test/Verifiable.Tests/Keri/KeriRotationTests.cs
@@ -93,7 +93,7 @@ internal sealed class KeriRotationTests
         KeriKeyState rotated = await KeriKeyStateMachine.RotateAsync(inception, rotation, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None);
 
         Assert.AreEqual(1, rotated.SequenceNumber);
-        CollectionAssert.AreEqual(NextKeys, (System.Collections.ICollection)rotated.SigningKeys, "The newly current keys are the revealed next keys.");
+        Assert.AreSequenceEqual(NextKeys, (System.Collections.ICollection)rotated.SigningKeys, "The newly current keys are the revealed next keys.");
         Assert.AreEqual(KeriThreshold.Unweighted(1), rotated.SigningThreshold);
         Assert.AreEqual(rotation.Said, rotated.LastEventSaid);
     }
@@ -116,7 +116,7 @@ internal sealed class KeriRotationTests
         KeriKeyState rotated = await KeriKeyStateMachine.RotateAsync(inception, rotation, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None);
 
         Assert.AreEqual(1, rotated.SequenceNumber);
-        CollectionAssert.AreEqual(subset, (System.Collections.ICollection)rotated.SigningKeys, "The newly current keys are exactly the revealed subset; the third committed key was held in reserve.");
+        Assert.AreSequenceEqual(subset, (System.Collections.ICollection)rotated.SigningKeys, "The newly current keys are exactly the revealed subset; the third committed key was held in reserve.");
     }
 
 
@@ -154,7 +154,7 @@ internal sealed class KeriRotationTests
 
         KeriKeyState rotated = await KeriKeyStateMachine.RotateAsync(inception, rotation, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None);
 
-        CollectionAssert.AreEqual(revealed, (System.Collections.ICollection)rotated.SigningKeys, "The augmented key is carried as a current key alongside the exposed pre-rotated keys.");
+        Assert.AreSequenceEqual(revealed, (System.Collections.ICollection)rotated.SigningKeys, "The augmented key is carried as a current key alongside the exposed pre-rotated keys.");
     }
 
 
@@ -171,7 +171,7 @@ internal sealed class KeriRotationTests
 
         KeriKeyState rotated = await KeriKeyStateMachine.RotateAsync(inception, rotation, AgileDigest, BaseMemoryPool.Shared, CancellationToken.None);
 
-        CollectionAssert.AreEqual(new[] { Backers[1], toAdd[0] }, (System.Collections.ICollection)rotated.Backers, "The removed backer is gone and the added backer is appended.");
+        Assert.AreSequenceEqual(new[] { Backers[1], toAdd[0] }, (System.Collections.ICollection)rotated.Backers, "The removed backer is gone and the added backer is appended.");
     }
 
 

--- a/test/Verifiable.Tests/Mdoc/MdocCborMsoReaderTests.cs
+++ b/test/Verifiable.Tests/Mdoc/MdocCborMsoReaderTests.cs
@@ -63,8 +63,8 @@ internal sealed class MdocCborMsoReaderTests
         Assert.IsTrue(nsDigests.ContainsKey(0u));
         Assert.IsTrue(nsDigests.ContainsKey(1u));
 
-        Assert.AreEqual(32, nsDigests[0u].Length, "SHA-256 digest is 32 bytes.");
-        Assert.AreEqual(32, nsDigests[1u].Length);
+        Assert.HasCount(32, nsDigests[0u], "SHA-256 digest is 32 bytes.");
+        Assert.HasCount(32, nsDigests[1u]);
     }
 
 
@@ -94,8 +94,8 @@ internal sealed class MdocCborMsoReaderTests
         Assert.AreEqual(CoseKeyCurves.P256, deviceKey.Curve);
         Assert.IsNotNull(deviceKey.X);
         Assert.IsNotNull(deviceKey.Y);
-        Assert.AreEqual(32, deviceKey.X!.Value.Length);
-        Assert.AreEqual(32, deviceKey.Y!.Value.Length);
+        Assert.HasCount(32, deviceKey.X!.Value);
+        Assert.HasCount(32, deviceKey.Y!.Value);
         Assert.IsNull(mso.DeviceKeyInfo.EncodedKeyAuthorizations);
         Assert.IsNull(mso.DeviceKeyInfo.EncodedKeyInfo);
     }

--- a/test/Verifiable.Tests/OAuth/AuthZenAccessEvaluationEndpointTests.cs
+++ b/test/Verifiable.Tests/OAuth/AuthZenAccessEvaluationEndpointTests.cs
@@ -590,7 +590,7 @@ internal sealed class AuthZenAccessEvaluationEndpointTests
         }
 
         Assert.AreEqual(3, pages, "5 items at limit 2 paginate as 2 + 2 + 1.");
-        CollectionAssert.AreEqual(dataset, collected,
+        Assert.AreSequenceEqual(dataset, collected,
             "Every item is returned exactly once, in order, across the pages (empty next_token signals the end).");
     }
 

--- a/test/Verifiable.Tests/OAuth/AuthorizationServerFeatureTests.cs
+++ b/test/Verifiable.Tests/OAuth/AuthorizationServerFeatureTests.cs
@@ -123,8 +123,13 @@ internal sealed class AuthorizationServerFeatureTests
     public void PolicyProfileEqualityIsByCode()
     {
         //Round 4.8 — built-in values are equal to themselves, distinct from
-        //each other; the dynamic-enum pattern's contract.
-        Assert.AreEqual(PolicyProfile.Fapi20, PolicyProfile.Fapi20,
+        //each other; the dynamic-enum pattern's contract. The self-comparison
+        //is against an independently retrieved copy (via the Profiles registry)
+        //rather than the same expression twice, so the check exercises the
+        //Code == other.Code comparison instead of a compile-time tautology.
+        PolicyProfile fapi20FromRegistry = PolicyProfile.Profiles.First(profile => profile.Code == PolicyProfile.Fapi20.Code);
+
+        Assert.AreEqual(PolicyProfile.Fapi20, fapi20FromRegistry,
             "Strict equals Strict.");
         Assert.AreNotEqual(PolicyProfile.Fapi20, PolicyProfile.Haip10,
             "Strict and Haip have different codes; they must not be equal.");

--- a/test/Verifiable.Tests/OAuth/ClientIdMetadataDocumentsResolvingTests.cs
+++ b/test/Verifiable.Tests/OAuth/ClientIdMetadataDocumentsResolvingTests.cs
@@ -312,7 +312,7 @@ internal sealed class ClientIdMetadataDocumentsResolvingTests
 
         Assert.IsTrue(resolution.IsResolved);
         Assert.IsNotNull(resolution.PrefetchedLogo);
-        CollectionAssert.AreEqual(logoBytes, resolution.PrefetchedLogo!.Value.ToArray());
+        Assert.AreSequenceEqual(logoBytes, resolution.PrefetchedLogo!.Value.ToArray());
         Assert.AreEqual("image/png", resolution.PrefetchedLogoContentType);
         Assert.Contains(LogoUrl, transport.Calls.ConvertAll(static c => c.Target.AbsoluteUri));
     }

--- a/test/Verifiable.Tests/OAuth/Contributors/AcrAmrClaimContributorTests.cs
+++ b/test/Verifiable.Tests/OAuth/Contributors/AcrAmrClaimContributorTests.cs
@@ -46,7 +46,7 @@ internal sealed class AcrAmrClaimContributorTests
         Assert.AreEqual(authContextTime.ToUnixTimeSeconds(), emitted[WellKnownJwtClaimNames.AuthTime]);
 
         IReadOnlyList<string> amr = (IReadOnlyList<string>)emitted[WellKnownJwtClaimNames.Amr];
-        CollectionAssert.AreEqual(ExpectedAmrPwdMfa, (System.Collections.ICollection)amr);
+        Assert.AreSequenceEqual(ExpectedAmrPwdMfa, (System.Collections.ICollection)amr);
     }
 
 

--- a/test/Verifiable.Tests/OAuth/DpopBoundRefreshTests.cs
+++ b/test/Verifiable.Tests/OAuth/DpopBoundRefreshTests.cs
@@ -6,6 +6,7 @@ using Verifiable.OAuth;
 using Verifiable.OAuth.AuthCode;
 using Verifiable.OAuth.AuthCode.States;
 using Verifiable.OAuth.Client;
+using Verifiable.OAuth.Dpop;
 using Verifiable.OAuth.Server;
 using Verifiable.Server;
 using Verifiable.Tests.TestInfrastructure;
@@ -147,6 +148,129 @@ internal sealed class DpopBoundRefreshTests
             ?? throw new AssertFailedException("The refreshed access-token JWT must carry cnf.jkt under DPoP issuance.");
         Assert.AreEqual(expectedThumbprint, wireJkt,
             "The refreshed access token's cnf.jkt must equal the SAME DPoP key's RFC 7638 thumbprint the refresh proof was built for.");
+    }
+
+
+    /// <summary>
+    /// Forces the RFC 9449 §8.1 <c>use_dpop_nonce</c> retry branch to fire on the REFRESH leg
+    /// itself, not merely at token exchange. The nonce
+    /// <see cref="DpopSenderConstrainedRefreshTokenRefreshesThroughRealClientAsync"/> caches during
+    /// its exchange leg is still inside <see cref="WellKnownDpopValues.DefaultNonceValidityWindow"/>
+    /// at refresh time under a non-advancing clock, so that test can pass whether or not
+    /// <see cref="AuthCodeFlowHandlers.RefreshAsync(RefreshTokenRequest, OAuthClientInfrastructure, ClientRegistration, ExchangeContext, ClientAssertionOptions?, System.Threading.CancellationToken)"/>
+    /// actually retries on the refresh POST — it never has to. Advancing <see cref="TimeProvider"/>
+    /// past the nonce's validity window between the two legs expires the cached nonce, so the first
+    /// refresh attempt draws a fresh <c>400 error=use_dpop_nonce</c> challenge from
+    /// <see cref="Verifiable.OAuth.AuthCode.Server.DpopTokenEndpointValidation"/> and only a working
+    /// retry lets the refresh succeed at all.
+    /// </summary>
+    [TestMethod]
+    public async Task DpopBoundRefreshRetriesOnUseDpopNonceChallengeAsync()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        using VerifierKeyMaterial material = host.RegisterDpopClient(ClientId, ClientBaseUri);
+        host.EnableDpop();
+
+        using DpopClientFixture fixture = await host.CreateDpopEnabledOAuthClientAsync(
+            material.Registration, RedirectUri.OriginalString, TestContext.CancellationToken).ConfigureAwait(false);
+
+        //Step 1 — PAR, over the real wire through the DPoP-wired client.
+        AuthCodeFlowEndpointResult parResult = await fixture.Client.AuthCode.StartParAsync(
+            fixture.Registration, RedirectUri, OAuthFormEncodedFields.Empty, TestContext.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Redirect, parResult.Outcome,
+            $"Expected PAR to yield a redirect. ErrorCode={parResult.ErrorCode} ErrorDescription={parResult.ErrorDescription}");
+
+        string flowId = fixture.ClientFlowStore.Keys.Single();
+        ParCompletedState parCompleted = (ParCompletedState)fixture.ClientFlowStore[flowId];
+
+        //Step 2 — Authorize, dispatched in-process on the same EndpointServer instance the Kestrel
+        //host serves, exactly as the exchange-leg test above.
+        RequestFields authorizeFields = new()
+        {
+            [OAuthRequestParameterNames.ClientId] = ClientId,
+            [OAuthRequestParameterNames.RequestUri] = parCompleted.Par.RequestUri.ToString()
+        };
+        ExchangeContext authorizeContext = new();
+        authorizeContext.SetSubjectId(SubjectId);
+
+        ServerHttpResponse authorizeResponse = await host.DispatchAtEndpointAsync(
+            material.Registration.TenantId.Value, WellKnownEndpointNames.AuthCodeAuthorize,
+            WellKnownHttpMethods.Get, authorizeFields, authorizeContext, TestContext.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.AreEqual(302, authorizeResponse.StatusCode,
+            $"Expected redirect from authorize. Body: {authorizeResponse.Body}");
+
+        string code = TestBrowser.ExtractQueryParam(authorizeResponse.Location!, OAuthRequestParameterNames.Code)
+            ?? throw new AssertFailedException($"Authorize redirect missing code. Location: {authorizeResponse.Location}");
+        string? iss = TestBrowser.ExtractQueryParam(authorizeResponse.Location!, OAuthRequestParameterNames.Iss);
+
+        //Step 3 — Callback: client-side state transition ready for token exchange.
+        Dictionary<string, string> callbackFields = new(StringComparer.Ordinal)
+        {
+            [OAuthRequestParameterNames.Code] = code,
+            [OAuthRequestParameterNames.State] = flowId
+        };
+        if(iss is not null)
+        {
+            callbackFields[OAuthRequestParameterNames.Iss] = iss;
+        }
+
+        AuthCodeFlowEndpointResult callbackResult = await fixture.Client.AuthCode.HandleCallbackAsync(
+            fixture.Registration, new OAuthFormEncodedFields(callbackFields), TestContext.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Ok, callbackResult.Outcome,
+            $"Callback must succeed. ErrorCode={callbackResult.ErrorCode} ErrorDescription={callbackResult.ErrorDescription}");
+
+        //Step 4 — Token, over the real wire. The client has no cached DPoP nonce yet, so the AS
+        //challenges once (RFC 9449 §8.1) and the client retries with the echoed nonce — the SAME
+        //nonce that must be neutralised below before it can prove anything about the refresh leg.
+        AuthCodeFlowEndpointResult tokenResult = await fixture.Client.AuthCode.ExchangeTokenAsync(
+            fixture.Registration, flowId, TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Ok, tokenResult.Outcome,
+            $"Expected token issuance success. ErrorCode={tokenResult.ErrorCode} ErrorDescription={tokenResult.ErrorDescription}");
+
+        string originalAccessToken = (string)tokenResult.Body![OAuthRequestParameterNames.AccessToken];
+        string originalRefreshToken = (string)tokenResult.Body![OAuthRequestParameterNames.RefreshToken];
+        Assert.IsFalse(string.IsNullOrEmpty(originalRefreshToken), "The initial DPoP-bound issuance must include a refresh_token.");
+
+        //Confirm the exchange leg actually left a nonce cached for the token endpoint's authority —
+        //otherwise expiring it below would prove nothing about a genuine retry.
+        string authority = InMemoryDpopNonceCache.AuthorityFor(fixture.Registration.AuthorizationServerIssuer);
+        Assert.IsNotNull(fixture.NonceCache.Lookup(authority),
+            "Token exchange must have cached a DPoP nonce for the token endpoint's authority before the refresh leg runs.");
+
+        //Advance the shared clock (client and server alike) past the nonce's validity window. The
+        //client still attaches the cached nonce on its first refresh attempt — LookupDpopNonce still
+        //returns it — but the server's issuedAt check now rejects it, forcing a fresh
+        //use_dpop_nonce challenge on the refresh POST specifically.
+        TimeProvider.Advance(WellKnownDpopValues.DefaultNonceValidityWindow + TimeSpan.FromSeconds(1));
+
+        //Step 5 — Refresh, over the real wire. If SendTokenRequestWithDpopRetryAsync's retry did not
+        //fire on this leg, the first (and only) attempt would fail with use_dpop_nonce and this
+        //assertion would fail outright.
+        RefreshTokenRequest refreshRequest = new()
+        {
+            ClientId = fixture.Registration.ClientId.Value,
+            RefreshToken = originalRefreshToken
+        };
+        AuthCodeFlowEndpointResult refreshResult = await fixture.Client.AuthCode.RefreshAsync(
+            fixture.Registration, refreshRequest, TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Ok, refreshResult.Outcome,
+            $"Refresh must succeed by retrying past the expired-nonce challenge on the refresh leg itself. ErrorCode={refreshResult.ErrorCode} ErrorDescription={refreshResult.ErrorDescription}");
+
+        string newAccessToken = (string)refreshResult.Body![OAuthRequestParameterNames.AccessToken];
+        Assert.IsFalse(string.IsNullOrEmpty(newAccessToken), "The AS must mint a fresh access token on refresh.");
+        Assert.AreNotEqual(originalAccessToken, newAccessToken,
+            "Refresh must issue a fresh access token, not return the original.");
+        Assert.AreEqual(WellKnownAuthenticationSchemes.DPoP, (string)refreshResult.Body[OAuthRequestParameterNames.TokenType]!,
+            "The refreshed access token must remain DPoP-bound (token_type=DPoP) after the nonce-retry round trip.");
+
+        string expectedThumbprint = fixture.DpopKey.GetThumbprint(TestHostShell.Base64UrlEncoder, TestHostShell.MemoryPool);
+        string wireJkt = JwtPayloadReader.ReadCnfJkt(newAccessToken)
+            ?? throw new AssertFailedException("The refreshed access-token JWT must carry cnf.jkt under DPoP issuance.");
+        Assert.AreEqual(expectedThumbprint, wireJkt,
+            "The refreshed access token's cnf.jkt must equal the SAME DPoP key's RFC 7638 thumbprint the retried refresh proof was built for.");
     }
 
 

--- a/test/Verifiable.Tests/OAuth/FederationListEndpointTests.cs
+++ b/test/Verifiable.Tests/OAuth/FederationListEndpointTests.cs
@@ -87,7 +87,7 @@ internal sealed class FederationListEndpointTests
 
         List<string> ids = ParseStringArray(body);
         Assert.HasCount(3, ids, "All three subordinates must be listed.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { alice.Value, bob.Value, carol.Value },
             ids.ToArray(),
             "The §8.2 array must preserve the membership order the delegate returned.");

--- a/test/Verifiable.Tests/OAuth/FederationTrustMarkListEndpointTests.cs
+++ b/test/Verifiable.Tests/OAuth/FederationTrustMarkListEndpointTests.cs
@@ -87,7 +87,7 @@ internal sealed class FederationTrustMarkListEndpointTests
 
         List<string> ids = ParseStringArray(body);
         Assert.HasCount(2, ids, "Both trust-marked subjects must be listed.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { alice.Value, bob.Value },
             ids.ToArray(),
             "The §8.5 array must preserve the membership order the delegate returned.");

--- a/test/Verifiable.Tests/OAuth/IdJagGrantTests.cs
+++ b/test/Verifiable.Tests/OAuth/IdJagGrantTests.cs
@@ -1190,7 +1190,7 @@ internal sealed class IdJagGrantTests
         using JsonDocument payload = DecodePayload(jag);
         string[] resourceClaim = [.. payload.RootElement.GetProperty(OAuthRequestParameterNames.Resource)
             .EnumerateArray().Select(static e => e.GetString()!)];
-        CollectionAssert.AreEqual(grantedResources, resourceClaim);
+        Assert.AreSequenceEqual(grantedResources, resourceClaim);
     }
 
 
@@ -2714,7 +2714,7 @@ internal sealed class IdJagGrantTests
         Assert.AreEqual("urn:mace:incommon:iap:silver", claims.GetProperty(WellKnownJwtClaimNames.Acr).GetString());
         string[] expectedAmr = ["mfa", "hwk"];
         string[] amr = [.. claims.GetProperty(WellKnownJwtClaimNames.Amr).EnumerateArray().Select(static e => e.GetString()!)];
-        CollectionAssert.AreEqual(expectedAmr, amr);
+        Assert.AreSequenceEqual(expectedAmr, amr);
     }
 
 

--- a/test/Verifiable.Tests/OAuth/JarmResponseTests.cs
+++ b/test/Verifiable.Tests/OAuth/JarmResponseTests.cs
@@ -5,6 +5,7 @@ using Verifiable.Cryptography;
 using Verifiable.JCose;
 using Verifiable.Json;
 using Verifiable.OAuth;
+using Verifiable.OAuth.Client;
 using Verifiable.OAuth.Jar;
 using Verifiable.OAuth.Jarm;
 using Verifiable.Tests.TestDataProviders;
@@ -159,6 +160,73 @@ internal sealed class JarmResponseTests
         Assert.IsFalse(result.IsValid);
         Assert.IsFalse(isResolverInvoked);
         Assert.IsNull(result.Parameters);
+    }
+
+
+    [TestMethod]
+    public async Task RejectsIssuerAbsentFromKnownAuthorizationServerStore()
+    {
+        //RFC 9207 §4: an iss that ordinally matches the expected issuer still is not a
+        //valid issuer for the response unless it also resolves to a known, uniquely-
+        //configured authorization server in the application's own store — and, exactly
+        //like an unexpected issuer, it must never trigger key resolution.
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory serverPublic = keys.PublicKey;
+        using PrivateKeyMemory serverPrivate = keys.PrivateKey;
+
+        string responseJwt = await IssueAsync(serverPrivate, new Dictionary<string, object>
+        {
+            ["code"] = "abc"
+        }).ConfigureAwait(false);
+
+        bool isResolverInvoked = false;
+        ResolveJarmVerificationKeyDelegate resolver = (_, _, _) =>
+        {
+            isResolverInvoked = true;
+
+            return ValueTask.FromResult<PublicKeyMemory?>(serverPublic);
+        };
+
+        KnownAuthorizationServerIssuerResolver isKnownAuthorizationServerIssuer =
+            issuer => string.Equals(issuer, "https://other-as.example.com", StringComparison.Ordinal);
+
+        JarmResponseValidationResult result = await JarmResponseValidation.ValidateAsync(
+            responseJwt, Issuer, ClientId, AllowedAlgorithms, TimeProvider.GetUtcNow(),
+            resolver, PayloadDeserializer, TestSetup.Base64UrlDecoder, Pool,
+            isKnownAuthorizationServerIssuer,
+            cancellationToken: TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.IsFalse(result.IsIssuerValid);
+        Assert.IsFalse(result.IsValid);
+        Assert.IsFalse(isResolverInvoked);
+        Assert.IsNull(result.Parameters);
+    }
+
+
+    [TestMethod]
+    public async Task AcceptsIssuerPresentInKnownAuthorizationServerStore()
+    {
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory serverPublic = keys.PublicKey;
+        using PrivateKeyMemory serverPrivate = keys.PrivateKey;
+
+        string responseJwt = await IssueAsync(serverPrivate, new Dictionary<string, object>
+        {
+            ["code"] = "PyyFaux2o7Q0YfXBU32jhw.5FXSQpvr8akv9CeRDSd0QA"
+        }).ConfigureAwait(false);
+
+        KnownAuthorizationServerIssuerResolver isKnownAuthorizationServerIssuer =
+            issuer => string.Equals(issuer, Issuer, StringComparison.Ordinal);
+
+        JarmResponseValidationResult result = await ValidateAsync(
+            responseJwt, serverPublic, Issuer, ClientId, isKnownAuthorizationServerIssuer).ConfigureAwait(false);
+
+        Assert.IsTrue(result.IsIssuerValid);
+        Assert.IsTrue(result.IsSignatureValid);
+        Assert.IsTrue(result.IsValid);
+        Assert.AreEqual("PyyFaux2o7Q0YfXBU32jhw.5FXSQpvr8akv9CeRDSd0QA", result.Code);
     }
 
 
@@ -357,7 +425,8 @@ internal sealed class JarmResponseTests
         string responseJwt,
         PublicKeyMemory serverPublic,
         string expectedIssuer,
-        string expectedClientId)
+        string expectedClientId,
+        KnownAuthorizationServerIssuerResolver? isKnownAuthorizationServerIssuer = null)
     {
         ResolveJarmVerificationKeyDelegate resolver = (_, _, _) =>
             ValueTask.FromResult<PublicKeyMemory?>(serverPublic);
@@ -365,7 +434,7 @@ internal sealed class JarmResponseTests
         return await JarmResponseValidation.ValidateAsync(
             responseJwt, expectedIssuer, expectedClientId, AllowedAlgorithms,
             TimeProvider.GetUtcNow(), resolver, PayloadDeserializer,
-            TestSetup.Base64UrlDecoder, Pool,
+            TestSetup.Base64UrlDecoder, Pool, isKnownAuthorizationServerIssuer,
             cancellationToken: TestContext.CancellationToken).ConfigureAwait(false);
     }
 }

--- a/test/Verifiable.Tests/OAuth/JwtBearerRequestBuilderTests.cs
+++ b/test/Verifiable.Tests/OAuth/JwtBearerRequestBuilderTests.cs
@@ -96,7 +96,7 @@ internal sealed class JwtBearerRequestBuilderTests
     [TestMethod]
     public void ReservedParameterNamesCoverExactlyTheSetFromTheRfcTexts()
     {
-        CollectionAssert.AreEquivalent(
+        Assert.AreSequenceEqual(
             new[]
             {
                 OAuthRequestParameterNames.GrantType,
@@ -107,7 +107,8 @@ internal sealed class JwtBearerRequestBuilderTests
                 OAuthRequestParameterNames.ClientAssertion,
                 OAuthRequestParameterNames.ClientAssertionType
             },
-            JwtBearerRequestBuilder.ReservedParameterNames.ToArray());
+            JwtBearerRequestBuilder.ReservedParameterNames.ToArray(),
+            SequenceOrder.InAnyOrder);
     }
 
 

--- a/test/Verifiable.Tests/OAuth/OAuthAttackMitigationTests.cs
+++ b/test/Verifiable.Tests/OAuth/OAuthAttackMitigationTests.cs
@@ -307,6 +307,132 @@ internal sealed class OAuthAttackMitigationTests
     }
 
 
+    //RFC 9207 §4 — authorization-server issuer uniqueness (client-side, opt-in).
+    //
+    //Configuration hazard beyond §2.4: a callback whose iss string-matches the issuer this
+    //flow targeted — so every per-flow issuer check passes — yet does not correspond to a
+    //known, uniquely-configured authorization server in the application's own store. §4
+    //draws the client's obligation to ensure an issuer identifier uniquely names one
+    //authorization server, which the per-flow ordinal comparison cannot establish on its own.
+    //
+    //Mitigation: when the application wires a KnownAuthorizationServerIssuerResolver, the
+    //callback additionally requires a present iss to resolve to a known authorization server;
+    //membership in the application-owned, uniqueness-guaranteeing store is required, not
+    //merely an ordinal match against the flow's expected issuer. A null resolver opts out and
+    //leaves the per-flow check as the sole issuer gate.
+
+    [TestMethod]
+    public async Task Rfc9207Section4KnownIssuerResolverAcceptsCallbackFromKnownAuthorizationServer()
+    {
+        var store = new Dictionary<string, FlowState>();
+        (OAuthClientInfrastructure infrastructure, ClientRegistration registration) = CreateInfrastructureAndRegistration(
+            store,
+            PolicyProfile.Haip10,
+            knownIssuerResolver: KnownIssuers("https://as.example.com"));
+        await AuthCodeFlowHandlers.HandleParAsync(new Dictionary<string, string>(), DefaultRedirectUri, infrastructure, registration, TestContext.CancellationToken)
+            .ConfigureAwait(false);
+
+        string flowId = GetSingleFlowId(store);
+        AuthCodeFlowEndpointResult result = await AuthCodeFlowHandlers.HandleCallbackAsync(
+            new Dictionary<string, string>
+            {
+                [OAuthRequestParameterNames.Code] = "auth-code",
+                [OAuthRequestParameterNames.State] = flowId,
+                [OAuthRequestParameterNames.Iss] = "https://as.example.com"
+            },
+            infrastructure,
+            registration,
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Ok, result.Outcome,
+            "A callback whose iss is a known, uniquely-configured authorization server matching the flow must proceed.");
+        AssertAllClaimsSucceeded(result.ValidationClaims);
+    }
+
+
+    [TestMethod]
+    public async Task Rfc9207Section4KnownIssuerResolverRejectsIssuerAbsentFromTheApplicationStore()
+    {
+        var store = new Dictionary<string, FlowState>();
+
+        //The resolver knows a DIFFERENT authorization server than the one this registration
+        //pins, so the callback iss — which does ordinally match the flow's expected issuer, so
+        //every per-flow issuer check passes — is rejected solely because it is absent from the
+        //application's known, uniquely-configured store: the §4 requirement the per-flow check
+        //cannot enforce. The token endpoint is wired to redeem successfully so the chained
+        //HandleTokenAsync discriminates: a BadRequest can only mean the rejected callback
+        //persisted no AuthorizationCodeReceivedState.
+        (OAuthClientInfrastructure infrastructure, ClientRegistration registration) = CreateInfrastructureAndRegistration(
+            store,
+            PolicyProfile.Haip10,
+            tokenResponse: BuildTokenJson("at.123", "Bearer", 3600, null),
+            knownIssuerResolver: KnownIssuers("https://other-as.example.com"));
+        await AuthCodeFlowHandlers.HandleParAsync(new Dictionary<string, string>(), DefaultRedirectUri, infrastructure, registration, TestContext.CancellationToken)
+            .ConfigureAwait(false);
+
+        string flowId = GetSingleFlowId(store);
+        AuthCodeFlowEndpointResult callbackResult = await AuthCodeFlowHandlers.HandleCallbackAsync(
+            new Dictionary<string, string>
+            {
+                [OAuthRequestParameterNames.Code] = "auth-code",
+                [OAuthRequestParameterNames.State] = flowId,
+                [OAuthRequestParameterNames.Iss] = "https://as.example.com"
+            },
+            infrastructure,
+            registration,
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.BadRequest, callbackResult.Outcome,
+            "An iss absent from the application's known-issuer store must be rejected even when it matches the flow's expected issuer.");
+        Assert.AreEqual("invalid_request", callbackResult.ErrorCode);
+        Assert.IsTrue(
+            callbackResult.ErrorDescription is not null
+                && callbackResult.ErrorDescription.Contains("RFC 9207", StringComparison.Ordinal),
+            "The rejection must be attributed to the RFC 9207 §4 known-issuer gate.");
+
+        AuthCodeFlowEndpointResult tokenResult = await AuthCodeFlowHandlers.HandleTokenAsync(
+            new Dictionary<string, string> { [AuthCodeFlowRoutes.FlowIdField] = flowId },
+            infrastructure,
+            registration,
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.BadRequest, tokenResult.Outcome,
+            "A callback rejected by the §4 known-issuer gate must never persist state the token endpoint can redeem.");
+    }
+
+
+    [TestMethod]
+    public async Task Rfc9207Section4NullResolverLeavesPerFlowIssuerCheckUnchanged()
+    {
+        //Opt-out: with no resolver wired, the callback applies only the per-flow issuer check,
+        //so a present iss matching the flow's expected issuer proceeds exactly as it does
+        //without the §4 gate — the nullable slot means "not opted in", never "reject".
+        var store = new Dictionary<string, FlowState>();
+        (OAuthClientInfrastructure infrastructure, ClientRegistration registration) = CreateInfrastructureAndRegistration(
+            store,
+            PolicyProfile.Haip10,
+            knownIssuerResolver: null);
+        await AuthCodeFlowHandlers.HandleParAsync(new Dictionary<string, string>(), DefaultRedirectUri, infrastructure, registration, TestContext.CancellationToken)
+            .ConfigureAwait(false);
+
+        string flowId = GetSingleFlowId(store);
+        AuthCodeFlowEndpointResult result = await AuthCodeFlowHandlers.HandleCallbackAsync(
+            new Dictionary<string, string>
+            {
+                [OAuthRequestParameterNames.Code] = "auth-code",
+                [OAuthRequestParameterNames.State] = flowId,
+                [OAuthRequestParameterNames.Iss] = "https://as.example.com"
+            },
+            infrastructure,
+            registration,
+            TestContext.CancellationToken).ConfigureAwait(false);
+
+        Assert.AreEqual(AuthCodeFlowEndpointOutcome.Ok, result.Outcome,
+            "With no known-issuer resolver wired, the per-flow issuer check alone governs and a matching iss proceeds.");
+        AssertAllClaimsSucceeded(result.ValidationClaims);
+    }
+
+
     //RFC 9700 §4.7 — Cross-Site Request Forgery (CSRF)
     //
     //Attacker capability: A web attacker (A1 in RFC 9700 §3) that can cause the
@@ -516,7 +642,8 @@ internal sealed class OAuthAttackMitigationTests
         Dictionary<string, string>? captureFormFields = null,
         Dictionary<string, string>? captureTokenFields = null,
         Uri? revocationEndpoint = null,
-        bool useDefaultRevocationEndpoint = true)
+        bool useDefaultRevocationEndpoint = true,
+        KnownAuthorizationServerIssuerResolver? knownIssuerResolver = null)
     {
         Uri? resolvedRevocationEndpoint = revocationEndpoint
             ?? (useDefaultRevocationEndpoint ? new Uri("https://as.example.com/revoke") : null);
@@ -586,6 +713,7 @@ internal sealed class OAuthAttackMitigationTests
             resolveAuthorizationServerMetadataAsync: (issuer, context, ct) =>
                 ValueTask.FromResult(metadata),
             resolveCallbackValidator: ClientPolicyProfiles.DefaultResolveCallbackValidator,
+            isKnownAuthorizationServerIssuer: knownIssuerResolver,
             base64UrlEncoder: TestSetup.Base64UrlEncoder,
             timeProvider: TimeProvider);
 
@@ -600,6 +728,11 @@ internal sealed class OAuthAttackMitigationTests
 
         return (infrastructure, registration);
     }
+
+    //A resolver over an application-owned set of trusted, uniquely-configured issuers,
+    //compared by the same ordinal rule the library applies.
+    private static KnownAuthorizationServerIssuerResolver KnownIssuers(params string[] issuers) =>
+        issuer => Array.Exists(issuers, known => string.Equals(known, issuer, StringComparison.Ordinal));
 
     private static string GetSingleFlowId(Dictionary<string, FlowState> store)
     {

--- a/test/Verifiable.Tests/OAuth/Oid4VciWalletOfferTests.cs
+++ b/test/Verifiable.Tests/OAuth/Oid4VciWalletOfferTests.cs
@@ -263,7 +263,7 @@ internal sealed class Oid4VciWalletOfferTests
     private static void AssertOfferEquivalent(CredentialOffer expected, CredentialOffer actual)
     {
         Assert.AreEqual(expected.CredentialIssuer.OriginalString, actual.CredentialIssuer.OriginalString);
-        CollectionAssert.AreEqual(expected.CredentialConfigurationIds.ToArray(), actual.CredentialConfigurationIds.ToArray());
+        Assert.AreSequenceEqual(expected.CredentialConfigurationIds.ToArray(), actual.CredentialConfigurationIds.ToArray());
 
         Assert.AreEqual(expected.PreAuthorizedCodeGrant?.PreAuthorizedCode, actual.PreAuthorizedCodeGrant?.PreAuthorizedCode);
         Assert.AreEqual(expected.PreAuthorizedCodeGrant?.TxCode?.InputMode, actual.PreAuthorizedCodeGrant?.TxCode?.InputMode);

--- a/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
+++ b/test/Verifiable.Tests/OAuth/Oid4VpFlowIntegrationTests.cs
@@ -2281,7 +2281,7 @@ internal sealed class Oid4VpFlowIntegrationTests
             (PresentationBuilt)wallet.GetFlowState(walletFlowId).State;
         Assert.IsNotNull(presentationBuilt.Request.TransactionData,
             "ParseJar must have populated TransactionData from the signed JAR.");
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             transactionData.ToArray(),
             presentationBuilt.Request.TransactionData.ToArray(),
             "TransactionData must round-trip through the JAR exactly — hash inputs depend on byte equality.");

--- a/test/Verifiable.Tests/OAuth/Oidc10IdTokenNonceAudienceScenarioTests.cs
+++ b/test/Verifiable.Tests/OAuth/Oidc10IdTokenNonceAudienceScenarioTests.cs
@@ -178,6 +178,62 @@ internal sealed class Oidc10IdTokenNonceAudienceScenarioTests
 
 
     /// <summary>
+    /// An id_token validated through <see cref="Oidc10IdTokenValidator.ValidateAsync"/> is rejected with
+    /// <see cref="JwsAccessTokenValidationFailureReason.IssuerMismatch"/> when the relying party's
+    /// expected issuer does not equal the token's <c>iss</c> — the same shared-core check
+    /// <see cref="JwsAccessTokenValidatorTests.ValidatorRejectsIssuerMismatch"/> proves through the
+    /// access-token entry point, exercised here through the id_token entry point instead.
+    /// </summary>
+    [TestMethod]
+    public async Task IdTokenWithMismatchedIssuerIsRejected()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        host.SeedTestSubject(subject: SubjectId);
+        using VerifierKeyMaterial material = host.RegisterDpopClient(
+            ClientId, ClientBaseUri, profile: PolicyProfile.Rfc6749WithPkce);
+
+        string idToken = await DriveCodeExchangeForIdTokenAsync(
+            host, material, nonce: null, stampSessionId: false).ConfigureAwait(false);
+
+        Oidc10IdTokenValidationResult result = await ValidateAsRelyingPartyAsync(
+            idToken, material, expectedNonce: null, trustedAudiences: null,
+            expectedIssuerOverride: "https://wrong-issuer.example.com").ConfigureAwait(false);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(JwsAccessTokenValidationFailureReason.IssuerMismatch, result.FailureReason,
+            "An id_token whose iss does not equal the relying party's expected issuer must be rejected (OIDC Core §3.1.3.7).");
+    }
+
+
+    /// <summary>
+    /// An id_token validated through <see cref="Oidc10IdTokenValidator.ValidateAsync"/> is rejected with
+    /// <see cref="JwsAccessTokenValidationFailureReason.AudienceMismatch"/> when the relying party's
+    /// <c>client_id</c> is not a member of the token's <c>aud</c> — the same shared-core check
+    /// <see cref="JwsAccessTokenValidatorTests.ValidatorRejectsAudienceMismatch"/> proves through the
+    /// access-token entry point, exercised here through the id_token entry point instead.
+    /// </summary>
+    [TestMethod]
+    public async Task IdTokenWithMismatchedAudienceIsRejected()
+    {
+        await using TestHostShell host = new(TimeProvider);
+        host.SeedTestSubject(subject: SubjectId);
+        using VerifierKeyMaterial material = host.RegisterDpopClient(
+            ClientId, ClientBaseUri, profile: PolicyProfile.Rfc6749WithPkce);
+
+        string idToken = await DriveCodeExchangeForIdTokenAsync(
+            host, material, nonce: null, stampSessionId: false).ConfigureAwait(false);
+
+        Oidc10IdTokenValidationResult result = await ValidateAsRelyingPartyAsync(
+            idToken, material, expectedNonce: null, trustedAudiences: null,
+            expectedAudienceOverride: "https://unregistered-client.example.com").ConfigureAwait(false);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(JwsAccessTokenValidationFailureReason.AudienceMismatch, result.FailureReason,
+            "An id_token whose aud does not contain the relying party's client_id must be rejected (OIDC Core §3.1.3.7).");
+    }
+
+
+    /// <summary>
     /// Replaces the host's claim issuer with the standard rules plus a deployment contributor that
     /// adds a second, application-chosen audience to the ID Token — the shape the untrusted-audience
     /// scenarios validate against.
@@ -293,7 +349,9 @@ internal sealed class Oidc10IdTokenNonceAudienceScenarioTests
         string idToken,
         VerifierKeyMaterial material,
         string? expectedNonce,
-        IReadOnlyCollection<string>? trustedAudiences)
+        IReadOnlyCollection<string>? trustedAudiences,
+        string? expectedIssuerOverride = null,
+        string? expectedAudienceOverride = null)
     {
         ServerVerificationKeyResolverDelegate resolveKey = (kid, tenant, ctx, ct) =>
             ValueTask.FromResult<PublicKeyMemory?>(
@@ -302,8 +360,8 @@ internal sealed class Oidc10IdTokenNonceAudienceScenarioTests
 
         return await Oidc10IdTokenValidator.ValidateAsync(
             idToken,
-            material.Registration.IssuerUri!.OriginalString,
-            ClientId,
+            expectedIssuerOverride ?? material.Registration.IssuerUri!.OriginalString,
+            expectedAudienceOverride ?? ClientId,
             resolveKey,
             MicrosoftCryptographicFunctions.VerifyP256Async,
             JwsAccessTokenTestSupport.Parser,

--- a/test/Verifiable.Tests/OAuth/Rfc9207IssuerUniquenessTests.cs
+++ b/test/Verifiable.Tests/OAuth/Rfc9207IssuerUniquenessTests.cs
@@ -1,0 +1,115 @@
+using Verifiable.OAuth.Client;
+
+namespace Verifiable.Tests.OAuth;
+
+/// <summary>
+/// <see href="https://www.rfc-editor.org/rfc/rfc9207#section-4">RFC 9207 §4</see> / §2.4 client-side
+/// issuer validation for <see cref="AuthorizationServerIssuerValidation"/> over an application-owned
+/// known-issuer resolver. The application owns the authorization-server store and guarantees §4 issuer
+/// uniqueness in how it answers the resolver; the library validates an authorization response's
+/// <c>iss</c> against it (a known, uniquely-configured server that ordinally matches the requested one).
+/// </summary>
+[TestClass]
+internal sealed class Rfc9207IssuerUniquenessTests
+{
+    private static readonly Uri HonestIssuer = new("https://honest.as.example");
+    private static readonly Uri ImpersonatorIssuer = new("https://impersonator.as.example");
+    private static readonly Uri UnknownIssuer = new("https://unknown.as.example");
+
+
+    /// <summary>
+    /// A resolver over an application-owned set of trusted, uniquely-configured issuers, compared by the
+    /// same ordinal rule the library uses.
+    /// </summary>
+    private static KnownAuthorizationServerIssuerResolver KnownIssuers(params Uri[] issuers)
+    {
+        return issuer => Array.Exists(
+            issuers, known => string.Equals(known.OriginalString, issuer, StringComparison.Ordinal));
+    }
+
+
+    /// <summary>Happy path: the <c>iss</c> is the known, requested authorization server's own issuer.</summary>
+    [TestMethod]
+    public void AcceptsTheRequestedAuthorizationServer()
+    {
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer);
+
+        Assert.IsTrue(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+            HonestIssuer.OriginalString, HonestIssuer, isKnown));
+    }
+
+
+    /// <summary>
+    /// §2.4 mix-up defense: an <c>iss</c> that maps to a DIFFERENT known authorization server than the
+    /// one the request targeted is rejected, even though it is itself a trusted, known server.
+    /// </summary>
+    [TestMethod]
+    public void RejectsIssuerFromADifferentKnownAuthorizationServer()
+    {
+        //Both are trusted/known, but the request went to HonestIssuer while the response claims the
+        //distinct, also-known ImpersonatorIssuer.
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer, ImpersonatorIssuer);
+
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+            ImpersonatorIssuer.OriginalString, HonestIssuer, isKnown));
+    }
+
+
+    /// <summary>An <c>iss</c> the application's resolver does not know is rejected.</summary>
+    [TestMethod]
+    public void RejectsAnUnknownIssuer()
+    {
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer);
+
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+            UnknownIssuer.OriginalString, HonestIssuer, isKnown));
+    }
+
+
+    /// <summary>
+    /// The known-issuer requirement in isolation: an <c>iss</c> that ordinally MATCHES the requested
+    /// issuer is still rejected when the resolver does not know it — the response must resolve to a
+    /// positively known authorization server, not merely match what the request expected. (If the
+    /// known-issuer clause were dropped, the ordinal-equality clause alone would accept this.)
+    /// </summary>
+    [TestMethod]
+    public void RejectsAnUnknownIssuerEvenWhenItMatchesTheExpectedIssuer()
+    {
+        //The resolver knows only HonestIssuer; the request and response both use UnknownIssuer.
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer);
+
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+            UnknownIssuer.OriginalString, UnknownIssuer, isKnown));
+    }
+
+
+    /// <summary>
+    /// A missing or malformed <c>iss</c> is rejected as invalid input, not faulted on — this validates
+    /// untrusted wire data.
+    /// </summary>
+    [TestMethod]
+    public void RejectsNullOrWhitespaceIssuerWithoutThrowing()
+    {
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer);
+
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(null, HonestIssuer, isKnown));
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(string.Empty, HonestIssuer, isKnown));
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid("   ", HonestIssuer, isKnown));
+    }
+
+
+    /// <summary>
+    /// Ordinal (RFC 8414 §3.3 / RFC 9207 §2.4 code-point) comparison, not <see cref="Uri"/> normalization:
+    /// a trailing-slash variant of the expected issuer is rejected even when the resolver trusts that
+    /// variant, so only the ordinal match against the expected issuer can reject it.
+    /// </summary>
+    [TestMethod]
+    public void UsesOrdinalComparisonNotUriNormalization()
+    {
+        Uri issuerWithTrailingSlash = new("https://honest.as.example/");
+        KnownAuthorizationServerIssuerResolver isKnown = KnownIssuers(HonestIssuer, issuerWithTrailingSlash);
+
+        Assert.IsFalse(AuthorizationServerIssuerValidation.IsAuthorizationResponseIssuerValid(
+            issuerWithTrailingSlash.OriginalString, HonestIssuer, isKnown));
+    }
+}

--- a/test/Verifiable.Tests/OAuth/SiopCombinedResponseTests.cs
+++ b/test/Verifiable.Tests/OAuth/SiopCombinedResponseTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Time.Testing;
 using System.Buffers;
 using System.Text;
+using Verifiable.Core;
+using Verifiable.Core.Assessment;
 using Verifiable.Core.Model.SelectiveDisclosure;
 using Verifiable.Cryptography;
 using Verifiable.Cryptography.Context;
@@ -13,6 +15,7 @@ using Verifiable.OAuth.Oid4Vp.Server;
 using Verifiable.OAuth.Oid4Vp.Wallet;
 using Verifiable.OAuth.Siop;
 using Verifiable.OAuth.Siop.Wallet;
+using Verifiable.OAuth.Validation;
 using Verifiable.Tests.TestDataProviders;
 using Verifiable.Tests.TestInfrastructure;
 
@@ -161,6 +164,55 @@ internal sealed class SiopCombinedResponseTests
             Assert.IsTrue(parsed.KbJwtSignatureValid);
             Assert.AreNotEqual(RequestNonce, parsed.KbJwtNonce,
                 "The verifier's §12 nonce comparison must detect the replayed presentation.");
+        }
+    }
+
+
+    [TestMethod]
+    public async Task MismatchedKbJwtAudienceFailsTheAudBindingCheck()
+    {
+        //RFC 9901 KB-JWT aud binds the presentation to ONE Verifier; a wallet that signs
+        //against a different Client ID must fail KbJwtAudMatchesClientId even though its
+        //signature, sd_hash, and nonce binding are all otherwise intact.
+        const string WrongAudience = "https://attacker.example.com";
+
+        (string serializedSdJwt, PrivateKeyMemory holderPrivateKey, PublicKeyMemory issuerPublicKey) =
+            await IssuePidCredentialAsync("Alice", "Smith").ConfigureAwait(false);
+
+        using(holderPrivateKey)
+        using(issuerPublicKey)
+        {
+            string vpToken = await PresentWithKeyBindingAsync(
+                serializedSdJwt, holderPrivateKey, RequestNonce, WrongAudience)
+                .ConfigureAwait(false);
+
+            VpTokenParsed parsed = await VerifyPresentationAsync(vpToken, issuerPublicKey).ConfigureAwait(false);
+
+            //The rest of the pipeline verifies normally, so the failure asserted below is
+            //attributable solely to the aud check, not to a broken signature or a stale nonce.
+            Assert.IsTrue(parsed.CredentialSignatureValid, "The issuer-signed credential must verify.");
+            Assert.IsTrue(parsed.KbJwtSignatureValid, "The KB-JWT must verify against the cnf holder key.");
+            Assert.IsTrue(parsed.SdHashValid, "The KB-JWT sd_hash must match the presented disclosures.");
+            Assert.AreEqual(RequestNonce, parsed.KbJwtNonce);
+            Assert.AreEqual(WrongAudience, parsed.KbJwtAud);
+
+            ExchangeContext exchangeContext = new();
+            ValidationContext validationContext = new()
+            {
+                Context = exchangeContext,
+                Now = TimeProvider.GetUtcNow(),
+                ExpectedClientId = VerifierClientId,
+                KbJwtAud = parsed.KbJwtAud
+            };
+
+            List<Claim> claims = await ValidationChecks.CheckKbJwtAud(
+                validationContext, TestContext.CancellationToken).ConfigureAwait(false);
+
+            Assert.HasCount(1, claims);
+            Assert.AreEqual(ValidationClaimIds.KbJwtAudMatchesClientId, claims[0].Id);
+            Assert.AreEqual(ClaimOutcome.Failure, claims[0].Outcome,
+                "A KB-JWT aud that does not equal the Verifier's client_id must fail "
+                + "KbJwtAudMatchesClientId even though the rest of the presentation verifies.");
         }
     }
 

--- a/test/Verifiable.Tests/Resolver/DidDocumentOperationsTests.cs
+++ b/test/Verifiable.Tests/Resolver/DidDocumentOperationsTests.cs
@@ -72,7 +72,7 @@ internal sealed class DidDocumentOperationsTests
         Assert.AreEqual(Did, result.Id!.Id, "Add preserves the current document's id, not the payload's.");
         Assert.AreEqual(Context.DidCore11, result.Context!.Contexts![0], "Add preserves the current document's @context.");
         Assert.HasCount(2, result.VerificationMethod!);
-        CollectionAssert.AreEquivalent(ExpectedKeyOneAndTwo, result.VerificationMethod!.Select(static method => method.Id).ToArray());
+        Assert.AreSequenceEqual(ExpectedKeyOneAndTwo, result.VerificationMethod!.Select(static method => method.Id).ToArray(), SequenceOrder.InAnyOrder);
     }
 
 
@@ -115,10 +115,10 @@ internal sealed class DidDocumentOperationsTests
 
         DidDocument result = DidDocumentOperations.Apply(current, WellKnownDidRegistrationValues.AddToDidDocument, additions);
 
-        CollectionAssert.AreEquivalent(ExpectedKeyOneAndTwo, result.Authentication!.Select(static reference => reference.Id).ToArray());
-        CollectionAssert.AreEquivalent(ExpectedServiceOneAndTwo, result.Service!.Select(static service => service.Id!.ToString()).ToArray());
-        CollectionAssert.AreEquivalent(ExpectedControllerAAndB, result.Controller!.Select(static controller => controller.Did).ToArray());
-        CollectionAssert.AreEquivalent(ExpectedAkaAAndB, result.AlsoKnownAs!);
+        Assert.AreSequenceEqual(ExpectedKeyOneAndTwo, result.Authentication!.Select(static reference => reference.Id).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(ExpectedServiceOneAndTwo, result.Service!.Select(static service => service.Id!.ToString()).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(ExpectedControllerAAndB, result.Controller!.Select(static controller => controller.Did).ToArray(), SequenceOrder.InAnyOrder);
+        Assert.AreSequenceEqual(ExpectedAkaAAndB, result.AlsoKnownAs!, SequenceOrder.InAnyOrder);
     }
 
 
@@ -266,7 +266,7 @@ internal sealed class DidDocumentOperationsTests
             ]);
 
         Assert.HasCount(2, result.VerificationMethod!);
-        CollectionAssert.AreEquivalent(ExpectedKeyOneAndTwo, result.VerificationMethod!.Select(static method => method.Id).ToArray());
+        Assert.AreSequenceEqual(ExpectedKeyOneAndTwo, result.VerificationMethod!.Select(static method => method.Id).ToArray(), SequenceOrder.InAnyOrder);
     }
 
 

--- a/test/Verifiable.Tests/Resolver/WebVhCrossWireFlowTests.cs
+++ b/test/Verifiable.Tests/Resolver/WebVhCrossWireFlowTests.cs
@@ -168,7 +168,7 @@ internal sealed class WebVhCrossWireFlowTests
         //The wired resolve verified every entry (and witness) proof, and those verifications surfaced as OTel spans.
         List<string> cryptoSpans = [.. cryptoSpanNames];
         Assert.IsNotEmpty(cryptoSpans, "The wired resolve MUST emit OpenTelemetry crypto spans (the per-entry proof verifications).");
-        CollectionAssert.Contains(cryptoSpans, CryptoTelemetry.ActivityNames.Verify,
+        Assert.Contains(CryptoTelemetry.ActivityNames.Verify, cryptoSpans,
             "Resolving the multi-entry did:webvh log MUST emit a crypto.verify span for the entry-proof verification.");
 
         Assert.IsTrue(nodeA.WasRequested("/.well-known/did.jsonl"), "The DID Log MUST have been fetched over the socket.");
@@ -202,7 +202,7 @@ internal sealed class WebVhCrossWireFlowTests
         Assert.IsTrue(filesResult.IsSuccessful, $"The path DID URL MUST dereference across the wire. Error: {filesResult.DereferencingMetadata.Error?.Type}.");
 
         TaggedMemory<byte> filesBody = (TaggedMemory<byte>)filesResult.ContentStream!;
-        CollectionAssert.AreEqual(issuersFile, filesBody.Span.ToArray(), "The dereferenced content bytes MUST equal the served file.");
+        Assert.AreSequenceEqual(issuersFile, filesBody.Span.ToArray(), "The dereferenced content bytes MUST equal the served file.");
 
         Assert.IsTrue(nodeA.WasRequested("/governance/issuers.json"), "The path file MUST have been fetched over the socket.");
 

--- a/test/Verifiable.Tests/Resolver/WebVhDidUrlDereferencerTests.cs
+++ b/test/Verifiable.Tests/Resolver/WebVhDidUrlDereferencerTests.cs
@@ -76,7 +76,7 @@ internal sealed class WebVhDidUrlDereferencerTests
         Assert.IsTrue(result.IsSuccessful, $"A did:webvh path DID URL MUST dereference. Error: {result.DereferencingMetadata.Error?.Type}.");
 
         TaggedMemory<byte> body = (TaggedMemory<byte>)result.ContentStream!;
-        CollectionAssert.AreEqual(served, body.Span.ToArray(), "The dereferenced content bytes MUST equal the served bytes.");
+        Assert.AreSequenceEqual(served, body.Span.ToArray(), "The dereferenced content bytes MUST equal the served bytes.");
     }
 
 
@@ -266,7 +266,7 @@ internal sealed class WebVhDidUrlDereferencerTests
         Assert.IsTrue(result.IsSuccessful, $"An explicit #files override MUST be dereferenced. Error: {result.DereferencingMetadata.Error?.Type}.");
 
         TaggedMemory<byte> body = (TaggedMemory<byte>)result.ContentStream!;
-        CollectionAssert.AreEqual(served, body.Span.ToArray(), "The content MUST come from the explicit #files endpoint.");
+        Assert.AreSequenceEqual(served, body.Span.ToArray(), "The content MUST come from the explicit #files endpoint.");
     }
 
 
@@ -295,7 +295,7 @@ internal sealed class WebVhDidUrlDereferencerTests
         Assert.IsTrue(result.IsSuccessful, $"A serviceEndpoint map #files override MUST be dereferenced. Error: {result.DereferencingMetadata.Error?.Type}.");
 
         TaggedMemory<byte> body = (TaggedMemory<byte>)result.ContentStream!;
-        CollectionAssert.AreEqual(served, body.Span.ToArray(), "The content MUST come from the map-form #files endpoint.");
+        Assert.AreSequenceEqual(served, body.Span.ToArray(), "The content MUST come from the map-form #files endpoint.");
     }
 
 

--- a/test/Verifiable.Tests/Resolver/WebVhParametersTests.cs
+++ b/test/Verifiable.Tests/Resolver/WebVhParametersTests.cs
@@ -130,8 +130,8 @@ internal sealed class WebVhParametersTests
         Assert.IsNotNull(next);
         Assert.AreEqual(prior.Method, next!.Method);
         Assert.AreEqual(prior.Scid, next.Scid);
-        CollectionAssert.AreEqual(prior.UpdateKeys, next.UpdateKeys);
-        CollectionAssert.AreEqual(prior.NextKeyHashes, next.NextKeyHashes);
+        Assert.AreSequenceEqual(prior.UpdateKeys, next.UpdateKeys);
+        Assert.AreSequenceEqual(prior.NextKeyHashes, next.NextKeyHashes);
         Assert.AreEqual(60, next.Ttl);
     }
 
@@ -408,7 +408,7 @@ internal sealed class WebVhParametersTests
 
         Assert.IsNull(error);
         Assert.IsNotNull(next);
-        CollectionAssert.AreEqual(prior.Watchers, next!.Watchers);
+        Assert.AreSequenceEqual(prior.Watchers, next!.Watchers);
     }
 
 

--- a/test/Verifiable.Tests/SecurityEvents/SsfHttpFlowTests.cs
+++ b/test/Verifiable.Tests/SecurityEvents/SsfHttpFlowTests.cs
@@ -155,6 +155,178 @@ internal sealed class SsfHttpFlowTests
 
 
     [TestMethod]
+    public async Task PushedSetWithWrongIssuerIsRejectedOverHttpWithInvalidIssuerError()
+    {
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory transmitterPublic = keys.PublicKey;
+        using PrivateKeyMemory transmitterPrivate = keys.PrivateKey;
+
+        HashSet<string> seenJtis = new(StringComparer.Ordinal);
+        IsSecurityEventTokenJtiSeenDelegate isSeen =
+            (jti, _, _) => ValueTask.FromResult(!seenJtis.Add(jti));
+
+        async Task<MinimalHttpResponse> ReceiverPushHandler(MinimalHttpRequest request, CancellationToken ct)
+        {
+            SsfDeliveryDecision decision = await SecurityEventTokenReception.ReceiveAsync(
+                request.Body, transmitterPublic, TransmitterIssuer, ReceiverAudience,
+                SecurityEventTestJson.DeserializePart, SecurityEventTestJson.DeserializePart,
+                TestSetup.Base64UrlDecoder, isSeen, new ExchangeContext(), Pool, cancellationToken: ct).ConfigureAwait(false);
+
+            if(decision.Outcome is SsfDeliveryOutcome.Accepted or SsfDeliveryOutcome.AcceptedDuplicate)
+            {
+                return new MinimalHttpResponse { StatusCode = 202 };
+            }
+
+            return new MinimalHttpResponse
+            {
+                StatusCode = 400,
+                ContentType = WellKnownMediaTypes.Application.Json,
+                Body = $$"""{"err":"{{decision.Error!.Err}}"}"""
+            };
+        }
+
+        await using MinimalHttpHost receiver = await MinimalHttpHost.StartAsync(
+            ReceiverPushHandler, TestContext.CancellationToken).ConfigureAwait(false);
+
+        //Signed by the real Transmitter key, but the iss claim names a different Transmitter
+        //than the one this Receiver expects for this stream.
+        string compact = await IssueAsync(
+            transmitterPrivate, jwtId: Guid.NewGuid().ToString("N"), issuer: "https://impostor.example/").ConfigureAwait(false);
+
+        using HttpClient transmitterClient = LoopbackTls.CreatePinnedHttpClient(receiver.Certificate);
+        Uri pushUrl = new(receiver.BaseAddress, "/ssf/push");
+
+        using HttpResponseMessage rejected = await PushAsync(transmitterClient, pushUrl, compact).ConfigureAwait(false);
+        string rejectedBody = await rejected.Content.ReadAsStringAsync(TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.AreEqual(400, (int)rejected.StatusCode, $"A wrong-issuer SET must not be acknowledged. Body: {rejectedBody}");
+
+        using JsonDocument errorDoc = JsonDocument.Parse(rejectedBody);
+        Assert.IsTrue(SsfDeliveryErrorCodes.IsInvalidIssuer(errorDoc.RootElement.GetProperty("err").GetString()!),
+            $"A SET whose iss does not match the expected Transmitter must be rejected with invalid_issuer. Body: {rejectedBody}");
+    }
+
+
+    [TestMethod]
+    public async Task PushedSetWithWrongAudienceIsRejectedOverHttpWithInvalidAudienceError()
+    {
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory transmitterPublic = keys.PublicKey;
+        using PrivateKeyMemory transmitterPrivate = keys.PrivateKey;
+
+        HashSet<string> seenJtis = new(StringComparer.Ordinal);
+        IsSecurityEventTokenJtiSeenDelegate isSeen =
+            (jti, _, _) => ValueTask.FromResult(!seenJtis.Add(jti));
+
+        async Task<MinimalHttpResponse> ReceiverPushHandler(MinimalHttpRequest request, CancellationToken ct)
+        {
+            SsfDeliveryDecision decision = await SecurityEventTokenReception.ReceiveAsync(
+                request.Body, transmitterPublic, TransmitterIssuer, ReceiverAudience,
+                SecurityEventTestJson.DeserializePart, SecurityEventTestJson.DeserializePart,
+                TestSetup.Base64UrlDecoder, isSeen, new ExchangeContext(), Pool, cancellationToken: ct).ConfigureAwait(false);
+
+            if(decision.Outcome is SsfDeliveryOutcome.Accepted or SsfDeliveryOutcome.AcceptedDuplicate)
+            {
+                return new MinimalHttpResponse { StatusCode = 202 };
+            }
+
+            return new MinimalHttpResponse
+            {
+                StatusCode = 400,
+                ContentType = WellKnownMediaTypes.Application.Json,
+                Body = $$"""{"err":"{{decision.Error!.Err}}"}"""
+            };
+        }
+
+        await using MinimalHttpHost receiver = await MinimalHttpHost.StartAsync(
+            ReceiverPushHandler, TestContext.CancellationToken).ConfigureAwait(false);
+
+        //Correct issuer, but the aud claim names a Receiver other than this one.
+        string compact = await IssueAsync(
+            transmitterPrivate, jwtId: Guid.NewGuid().ToString("N"), audience: "https://other-receiver.example/ssf").ConfigureAwait(false);
+
+        using HttpClient transmitterClient = LoopbackTls.CreatePinnedHttpClient(receiver.Certificate);
+        Uri pushUrl = new(receiver.BaseAddress, "/ssf/push");
+
+        using HttpResponseMessage rejected = await PushAsync(transmitterClient, pushUrl, compact).ConfigureAwait(false);
+        string rejectedBody = await rejected.Content.ReadAsStringAsync(TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.AreEqual(400, (int)rejected.StatusCode, $"A wrong-audience SET must not be acknowledged. Body: {rejectedBody}");
+
+        using JsonDocument errorDoc = JsonDocument.Parse(rejectedBody);
+        Assert.IsTrue(SsfDeliveryErrorCodes.IsInvalidAudience(errorDoc.RootElement.GetProperty("err").GetString()!),
+            $"A SET whose aud does not include this Receiver must be rejected with invalid_audience. Body: {rejectedBody}");
+    }
+
+
+    [TestMethod]
+    public async Task RejectedSetWithWrongIssuerDoesNotConsumeItsJtiSoAValidRedeliveryWithTheSameJtiIsAccepted()
+    {
+        PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
+            TestKeyMaterialProvider.CreateFreshP256KeyMaterial();
+        using PublicKeyMemory transmitterPublic = keys.PublicKey;
+        using PrivateKeyMemory transmitterPrivate = keys.PrivateKey;
+
+        HashSet<string> seenJtis = new(StringComparer.Ordinal);
+        IsSecurityEventTokenJtiSeenDelegate isSeen =
+            (jti, _, _) => ValueTask.FromResult(!seenJtis.Add(jti));
+
+        async Task<MinimalHttpResponse> ReceiverPushHandler(MinimalHttpRequest request, CancellationToken ct)
+        {
+            SsfDeliveryDecision decision = await SecurityEventTokenReception.ReceiveAsync(
+                request.Body, transmitterPublic, TransmitterIssuer, ReceiverAudience,
+                SecurityEventTestJson.DeserializePart, SecurityEventTestJson.DeserializePart,
+                TestSetup.Base64UrlDecoder, isSeen, new ExchangeContext(), Pool, cancellationToken: ct).ConfigureAwait(false);
+
+            if(decision.Outcome is SsfDeliveryOutcome.Accepted or SsfDeliveryOutcome.AcceptedDuplicate)
+            {
+                return new MinimalHttpResponse { StatusCode = 202 };
+            }
+
+            return new MinimalHttpResponse
+            {
+                StatusCode = 400,
+                ContentType = WellKnownMediaTypes.Application.Json,
+                Body = $$"""{"err":"{{decision.Error!.Err}}"}"""
+            };
+        }
+
+        await using MinimalHttpHost receiver = await MinimalHttpHost.StartAsync(
+            ReceiverPushHandler, TestContext.CancellationToken).ConfigureAwait(false);
+
+        using HttpClient transmitterClient = LoopbackTls.CreatePinnedHttpClient(receiver.Certificate);
+        Uri pushUrl = new(receiver.BaseAddress, "/ssf/push");
+
+        string jti = Guid.NewGuid().ToString("N");
+
+        //A wrong-issuer SET carrying jti J: rejected before the dedup check ever runs
+        //(SecurityEventTokenVerification validates iss/aud claims before consulting
+        //isJtiSeen), so J must not be recorded as seen.
+        string wrongIssuerSet = await IssueAsync(transmitterPrivate, jti, issuer: "https://impostor.example/").ConfigureAwait(false);
+
+        using HttpResponseMessage rejected = await PushAsync(transmitterClient, pushUrl, wrongIssuerSet).ConfigureAwait(false);
+        string rejectedBody = await rejected.Content.ReadAsStringAsync(TestContext.CancellationToken).ConfigureAwait(false);
+        Assert.AreEqual(400, (int)rejected.StatusCode, $"The wrong-issuer SET must not be acknowledged. Body: {rejectedBody}");
+
+        using(JsonDocument errorDoc = JsonDocument.Parse(rejectedBody))
+        {
+            Assert.IsTrue(SsfDeliveryErrorCodes.IsInvalidIssuer(errorDoc.RootElement.GetProperty("err").GetString()!),
+                $"The rejection must be invalid_issuer. Body: {rejectedBody}");
+        }
+
+        Assert.DoesNotContain(jti, seenJtis,
+            "A rejected SET's jti must not be recorded — dedup only runs after claim validation succeeds.");
+
+        //A correctly issued SET carrying the SAME jti must now be accepted: the earlier
+        //rejection did not burn J.
+        string validSet = await IssueAsync(transmitterPrivate, jti).ConfigureAwait(false);
+
+        Assert.AreEqual(202, (int)(await PushAsync(transmitterClient, pushUrl, validSet).ConfigureAwait(false)).StatusCode);
+        Assert.Contains(jti, seenJtis, "The valid redelivery must be processed and its jti recorded.");
+    }
+
+
+    [TestMethod]
     public async Task PollRoundTripDeliversVerifiesAndAcknowledgesOverHttp()
     {
         PublicPrivateKeyMaterial<PublicKeyMemory, PrivateKeyMemory> keys =
@@ -253,10 +425,11 @@ internal sealed class SsfHttpFlowTests
     }
 
 
-    private async Task<string> IssueAsync(PrivateKeyMemory signingKey, string jwtId) =>
+    private async Task<string> IssueAsync(
+        PrivateKeyMemory signingKey, string jwtId, string? issuer = null, string? audience = null) =>
         await SecurityEventTokenIssuance.IssueAsync(
-            TransmitterIssuer,
-            [ReceiverAudience],
+            issuer ?? TransmitterIssuer,
+            [audience ?? ReceiverAudience],
             jwtId,
             issuedAt: DateTimeOffset.UnixEpoch.AddSeconds(1615305159),
             [new SecurityEvent

--- a/test/Verifiable.Tests/SelectiveDisclosure/SdCwtSerializerTests.cs
+++ b/test/Verifiable.Tests/SelectiveDisclosure/SdCwtSerializerTests.cs
@@ -48,7 +48,7 @@ internal sealed class SdCwtSerializerTests
         string value = reader.ReadTextString();
         reader.ReadEndArray();
 
-        CollectionAssert.AreEqual(TestSalt, salt);
+        Assert.AreSequenceEqual(TestSalt, salt);
         Assert.AreEqual("given_name", name);
         Assert.AreEqual("John", value);
     }
@@ -70,7 +70,7 @@ internal sealed class SdCwtSerializerTests
         string value = reader.ReadTextString();
         reader.ReadEndArray();
 
-        CollectionAssert.AreEqual(TestSalt, salt);
+        Assert.AreSequenceEqual(TestSalt, salt);
         Assert.AreEqual("US", value);
     }
 
@@ -202,7 +202,7 @@ internal sealed class SdCwtSerializerTests
         using SdDisclosure parsed = SdCwtSerializer.ParseDisclosure(cbor, TestSalts.TestSaltTag, BaseMemoryPool.Shared);
 
         Assert.AreEqual("binary", parsed.ClaimName);
-        CollectionAssert.AreEqual(binaryData, (byte[])parsed.ClaimValue!);
+        Assert.AreSequenceEqual(binaryData, (byte[])parsed.ClaimValue!);
     }
 
 
@@ -216,7 +216,7 @@ internal sealed class SdCwtSerializerTests
         byte[] digest1 = SdCwtSerializer.ComputeDisclosureDigest(cbor, WellKnownHashAlgorithms.Sha256Iana);
         byte[] digest2 = SdCwtSerializer.ComputeDisclosureDigest(cbor, WellKnownHashAlgorithms.Sha256Iana);
 
-        CollectionAssert.AreEqual(digest1, digest2, "Digest must be deterministic.");
+        Assert.AreSequenceEqual(digest1, digest2, "Digest must be deterministic.");
     }
 
 
@@ -323,7 +323,7 @@ internal sealed class SdCwtSerializerTests
         byte[] cbor1 = SdCwtSerializer.SerializeDisclosure(disclosure, CborConformanceMode.Canonical);
         byte[] cbor2 = SdCwtSerializer.SerializeDisclosure(disclosure, CborConformanceMode.Canonical);
 
-        CollectionAssert.AreEqual(cbor1, cbor2, "Canonical encoding must be deterministic.");
+        Assert.AreSequenceEqual(cbor1, cbor2, "Canonical encoding must be deterministic.");
     }
 
 
@@ -352,7 +352,7 @@ internal sealed class SdCwtSerializerTests
             byte[] hash1 = SdCwtSerializer.ComputeSdHash(sdClaimsCbor, WellKnownHashAlgorithms.Sha256Iana);
             byte[] hash2 = SdCwtSerializer.ComputeSdHash(sdClaimsCbor, WellKnownHashAlgorithms.Sha256Iana);
 
-            CollectionAssert.AreEqual(hash1, hash2, "SD hash must be deterministic.");
+            Assert.AreSequenceEqual(hash1, hash2, "SD hash must be deterministic.");
         }
         finally
         {

--- a/test/Verifiable.Tests/Serialization/CborConverterTests.cs
+++ b/test/Verifiable.Tests/Serialization/CborConverterTests.cs
@@ -134,7 +134,7 @@ internal sealed class CborConverterTests
 
         var reader = new CborReader(originalCbor);
         byte[] value = reader.ReadByteString();
-        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03 }, value);
+        Assert.AreSequenceEqual(new byte[] { 0x01, 0x02, 0x03 }, value);
 
         var writer = new CborWriter(CborConformanceMode.Canonical);
         writer.WriteByteString([0x01, 0x02, 0x03]);
@@ -182,8 +182,8 @@ internal sealed class CborConverterTests
         var values = reader.ReadByteStringArray();
 
         Assert.HasCount(2, values);
-        CollectionAssert.AreEqual(new byte[] { 0x01 }, values[0]);
-        CollectionAssert.AreEqual(new byte[] { 0x02, 0x03 }, values[1]);
+        Assert.AreSequenceEqual(new byte[] { 0x01 }, values[0]);
+        Assert.AreSequenceEqual(new byte[] { 0x02, 0x03 }, values[1]);
 
         var writer = new CborWriter(CborConformanceMode.Canonical);
         writer.WriteByteStringArray(values);
@@ -313,7 +313,7 @@ internal sealed class CborConverterTests
         byte[]? value = reader.ReadNullableByteString();
 
         Assert.IsNotNull(value);
-        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02 }, value);
+        Assert.AreSequenceEqual(new byte[] { 0x01, 0x02 }, value);
     }
 
 

--- a/test/Verifiable.Tests/Serialization/EncodedCborItemTests.cs
+++ b/test/Verifiable.Tests/Serialization/EncodedCborItemTests.cs
@@ -75,7 +75,7 @@ internal sealed class EncodedCborItemTests
 
         //InnerBytes is a slice of WireBytes positioned at the byte-string
         //content offset.
-        Assert.AreEqual(1, item.InnerBytes.Length);
+        Assert.HasCount(1, item.InnerBytes);
         Assert.AreEqual(0xA0, item.InnerBytes.Span[0]);
     }
 

--- a/test/Verifiable.Tests/Serialization/JcsTests.cs
+++ b/test/Verifiable.Tests/Serialization/JcsTests.cs
@@ -204,7 +204,7 @@ internal sealed class JcsTests
         var result = Jcs.CanonicalizeToUtf8Bytes(input);
 
         var expected = Encoding.UTF8.GetBytes(/*lang=json,strict*/ """{"a":"b"}""");
-        CollectionAssert.AreEqual(expected, result);
+        Assert.AreSequenceEqual(expected, result);
     }
 
 

--- a/test/Verifiable.Tests/StatusList/StatusListTests.cs
+++ b/test/Verifiable.Tests/StatusList/StatusListTests.cs
@@ -303,7 +303,7 @@ internal sealed class StatusListTests
 
         ReadOnlySpan<byte> span = list.AsSpan();
 
-        Assert.AreEqual(2, span.Length);
+        Assert.HasCount(2, span);
         Assert.AreEqual((byte)0xB9, span[0]);
         Assert.AreEqual((byte)0xA3, span[1]);
     }

--- a/test/Verifiable.Tests/TestInfrastructure/ContextTypeTestHelpers.cs
+++ b/test/Verifiable.Tests/TestInfrastructure/ContextTypeTestHelpers.cs
@@ -208,7 +208,7 @@ internal static class ContextTypeTestHelpers
         var list = collection.ToList();
         foreach(var expected in expectedValues)
         {
-            CollectionAssert.Contains(list, expected, $"Collection should contain {expected}.");
+            Assert.Contains(expected, list, $"Collection should contain {expected}.");
         }
     }
 

--- a/test/Verifiable.Tests/Tpm/HwTpmCreateLoadTests.cs
+++ b/test/Verifiable.Tests/Tpm/HwTpmCreateLoadTests.cs
@@ -106,7 +106,7 @@ internal class HwTpmCreateLoadTests
             byte[] secondName = await LoadAndFlushAsync(created, parentHandle, pool, registry).ConfigureAwait(false);
 
             Assert.IsNotEmpty(firstName, "The loaded object Name must be non-empty.");
-            CollectionAssert.AreEqual(firstName, secondName, "Reloading the same blob must produce the same Name.");
+            Assert.AreSequenceEqual(firstName, secondName, "Reloading the same blob must produce the same Name.");
         }
         finally
         {

--- a/test/Verifiable.Tests/Tpm/HwTpmCreatePrimaryTests.cs
+++ b/test/Verifiable.Tests/Tpm/HwTpmCreatePrimaryTests.cs
@@ -264,7 +264,7 @@ internal class HwTpmCreatePrimaryTests
 
         Assert.IsNotNull(firstKeyName);
         Assert.IsNotNull(secondKeyName);
-        CollectionAssert.AreEqual(firstKeyName, secondKeyName, "Same template should produce same key name.");
+        Assert.AreSequenceEqual(firstKeyName, secondKeyName, "Same template should produce same key name.");
         TestContext.WriteLine($"Both keys have same name: {Convert.ToHexString(firstKeyName)}");
     }    
 }

--- a/test/Verifiable.Tests/Tpm/TpmExchangeTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmExchangeTests.cs
@@ -32,8 +32,8 @@ internal class TpmExchangeTests
 
         var exchange = new TpmExchange(0, 100, command, response);
 
-        Assert.AreEqual(command.Length, exchange.Command.Length);
-        Assert.AreEqual(response.Length, exchange.Response.Length);
+        Assert.HasCount(command.Length, exchange.Command);
+        Assert.HasCount(response.Length, exchange.Response);
         Assert.IsTrue(command.AsSpan().SequenceEqual(exchange.Command.Span));
         Assert.IsTrue(response.AsSpan().SequenceEqual(exchange.Response.Span));
     }

--- a/test/Verifiable.Tests/Tpm/TpmInHouseSimulatorSignTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmInHouseSimulatorSignTests.cs
@@ -229,7 +229,7 @@ internal sealed class TpmInHouseSimulatorSignTests
         Assert.AreEqual(TpmStConstants.TPM_ST_CREATION, primary.CreationTicket.Tag, "The ticket tag must be TPM_ST_CREATION.");
         Assert.AreEqual(TpmRh.TPM_RH_OWNER, primary.CreationTicket.Hierarchy, "The ticket hierarchy must be the owner hierarchy.");
         Assert.IsFalse(primary.CreationTicket.IsNull, "The creation ticket must be a real HMAC, not a NULL ticket.");
-        Assert.AreEqual(P256ComponentSize, primary.CreationTicket.Digest.Length, "The creation ticket digest is a SHA-256 HMAC.");
+        Assert.HasCount(P256ComponentSize, primary.CreationTicket.Digest, "The creation ticket digest is a SHA-256 HMAC.");
     }
 
     [TestMethod]

--- a/test/Verifiable.Tests/Tpm/TpmParameterEncryptionExecutorTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmParameterEncryptionExecutorTests.cs
@@ -233,7 +233,7 @@ internal sealed class TpmParameterEncryptionExecutorTests
             ReadOnlyMemory<byte> nonceCaller = ExtractCommandNonceCaller(observedCommand);
             ReadOnlyMemory<byte> encryptedFirstParam = ExtractCommandFirstParameterData(observedCommand);
 
-            Assert.AreEqual(PlaintextLength, encryptedFirstParam.Length, "Parameter encryption must not change the data length.");
+            Assert.HasCount(PlaintextLength, encryptedFirstParam, "Parameter encryption must not change the data length.");
             Assert.IsFalse(encryptedFirstParam.Span.SequenceEqual(plaintext.Memory.Span[..PlaintextLength]), "The first command parameter must be encrypted on the wire.");
 
             //Command direction (Part 1 §19.2): nonceNewer = nonceCaller, nonceOlder = nonceTPM (the session's
@@ -378,7 +378,7 @@ internal sealed class TpmParameterEncryptionExecutorTests
             ReadOnlyMemory<byte> nonceCaller = ExtractCommandNonceCaller(observedCommand);
             ReadOnlyMemory<byte> encryptedFirstParam = ExtractCommandFirstParameterData(observedCommand);
 
-            Assert.AreEqual(PlaintextLength, encryptedFirstParam.Length, "Parameter encryption must not change the data length.");
+            Assert.HasCount(PlaintextLength, encryptedFirstParam, "Parameter encryption must not change the data length.");
             Assert.IsFalse(encryptedFirstParam.Span.SequenceEqual(plaintext.Memory.Span[..PlaintextLength]), "The first command parameter must be encrypted on the wire.");
 
             //Command direction (Part 1 §19.2): nonceNewer = nonceCaller, nonceOlder = nonceTPM (the session's

--- a/test/Verifiable.Tests/Tpm/TpmReaderTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmReaderTests.cs
@@ -84,7 +84,7 @@ internal class TpmReaderTests
 
         ReadOnlySpan<byte> bytes = reader.ReadBytes(3);
 
-        Assert.AreEqual(3, bytes.Length);
+        Assert.HasCount(3, bytes);
         Assert.AreEqual((byte)0x01, bytes[0]);
         Assert.AreEqual((byte)0x02, bytes[1]);
         Assert.AreEqual((byte)0x03, bytes[2]);
@@ -100,7 +100,7 @@ internal class TpmReaderTests
 
         ReadOnlySpan<byte> data = reader.ReadTpm2b();
 
-        Assert.AreEqual(3, data.Length);
+        Assert.HasCount(3, data);
         Assert.AreEqual((byte)0xAA, data[0]);
         Assert.AreEqual((byte)0xBB, data[1]);
         Assert.AreEqual((byte)0xCC, data[2]);
@@ -115,7 +115,7 @@ internal class TpmReaderTests
 
         ReadOnlySpan<byte> peeked = reader.PeekBytes(2);
 
-        Assert.AreEqual(2, peeked.Length);
+        Assert.HasCount(2, peeked);
         Assert.AreEqual(0, reader.Consumed);
         Assert.AreEqual(3, reader.Remaining);
     }

--- a/test/Verifiable.Tests/Tpm/TpmReaderWriterRoundtripTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmReaderWriterRoundtripTests.cs
@@ -65,7 +65,7 @@ internal class TpmReaderWriterRoundtripTests
         var reader = new TpmReader(buffer);
         ReadOnlySpan<byte> parsed = reader.ReadTpm2b();
 
-        Assert.AreEqual(originalData.Length, parsed.Length);
+        Assert.HasCount(originalData.Length, parsed);
         Assert.IsTrue(originalData.AsSpan().SequenceEqual(parsed));
     }
 
@@ -81,7 +81,7 @@ internal class TpmReaderWriterRoundtripTests
         var reader = new TpmReader(buffer);
         ReadOnlySpan<byte> parsed = reader.ReadTpm2b();
 
-        Assert.AreEqual(0, parsed.Length);
+        Assert.HasCount(0, parsed);
     }
 
     [TestMethod]

--- a/test/Verifiable.Tests/Tpm/TpmSessionTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmSessionTests.cs
@@ -45,7 +45,7 @@ internal sealed class TpmSessionTests
         Assert.AreEqual(TpmSeConstants.TPM_SE_HMAC, input.SessionType, "Session type must be HMAC.");
         Assert.AreEqual(authHash, input.AuthHash, "AuthHash must be the requested algorithm.");
         Assert.IsTrue(input.EncryptedSalt.IsEmpty, "An unsalted session must carry an empty encryptedSalt.");
-        Assert.AreEqual(digestSize, input.NonceCaller.Length, "nonceCaller must be a full-digest-size caller nonce (>= 16 octets per Part 3 §11.1).");
+        Assert.HasCount(digestSize, input.NonceCaller, "nonceCaller must be a full-digest-size caller nonce (>= 16 octets per Part 3 §11.1).");
         Assert.AreEqual(TpmCcConstants.TPM_CC_StartAuthSession, input.CommandCode);
     }
 

--- a/test/Verifiable.Tests/Tpm/TpmSimulatorLifecycleTests.cs
+++ b/test/Verifiable.Tests/Tpm/TpmSimulatorLifecycleTests.cs
@@ -274,7 +274,7 @@ internal sealed class TpmSimulatorLifecycleTests
         Assert.AreEqual(TpmRcConstants.TPM_RC_SUCCESS, (TpmRcConstants)header.Code);
 
         ReadOnlySpan<byte> outData = reader.ReadTpm2b();
-        Assert.AreEqual(0, outData.Length);
+        Assert.HasCount(0, outData);
         Assert.AreEqual(TpmRcConstants.TPM_RC_SUCCESS, (TpmRcConstants)reader.ReadUInt32());
     }
 

--- a/test/Verifiable.Tests/Vcalm/VerifiablePresentationRequestTests.cs
+++ b/test/Verifiable.Tests/Vcalm/VerifiablePresentationRequestTests.cs
@@ -141,7 +141,7 @@ internal sealed class VerifiablePresentationRequestTests
         Assert.AreEqual(VcalmParseFailure.None, request.Failure);
         DidAuthenticationQuery didAuth = Assert.IsInstanceOfType<DidAuthenticationQuery>(request.Query[0]);
         Assert.AreEqual(VcalmQueryTypes.DidAuthentication, didAuth.Type);
-        CollectionAssert.AreEquivalent(KeyAndWebMethods, didAuth.AcceptedMethods.ToArray());
+        Assert.AreSequenceEqual(KeyAndWebMethods, didAuth.AcceptedMethods.ToArray(), SequenceOrder.InAnyOrder);
         Assert.Contains("ecdsa-rdfc-2019", didAuth.AcceptedCryptosuites);
 
         //§3.4.3 holder predicate: a did:key holder is accepted, a did:cheqd holder is not.
@@ -218,7 +218,7 @@ internal sealed class VerifiablePresentationRequestTests
             Assert.IsInstanceOfType<AuthorizationCapabilityRequestQuery>(request.Query[0]);
         Assert.HasCount(1, capability.CapabilityQuery);
         Assert.AreEqual("a-memorable-name", capability.CapabilityQuery[0].ReferenceId);
-        CollectionAssert.AreEquivalent(ReadAndWriteActions, capability.CapabilityQuery[0].AllowedAction.ToArray());
+        Assert.AreSequenceEqual(ReadAndWriteActions, capability.CapabilityQuery[0].AllowedAction.ToArray(), SequenceOrder.InAnyOrder);
     }
 
 

--- a/test/Verifiable.Tests/packages.lock.json
+++ b/test/Verifiable.Tests/packages.lock.json
@@ -79,11 +79,12 @@
       },
       "Microsoft.Reactive.Testing": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "1KLmcpM299ZSA8ZjCbXApM/TVeaJJGZZz8nEJ8SWszf/JYcPqhzeg5s2rhCBIWuSoBaga3lny4EATs4fi/ME5A==",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "noVW6VX7u8nxYmajOF/jrLJ435D3Awqr7WdSl1TzVtff6xP3+u38XAUnCUXpKNd4I4mJHMT8jb6fR9L+iernZA==",
         "dependencies": {
-          "System.Reactive": "6.1.0"
+          "System.Reactive": "7.0.0",
+          "xunit.v3.assert.source": "3.2.2"
         }
       },
       "Microsoft.Sbom.Targets": {
@@ -94,32 +95,32 @@
       },
       "Microsoft.Testing.Extensions.AzureDevOpsReport": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "08SCwk+ZeWzmqdXOmatulRKrc07hZKXGs3ODPTDS988Jcg8uSRiB8AR5AAZPnAky2XHL8xMuSJF42F//p+Yc2Q==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "I+TRtc7XPGaVK6wf4CVWRBNTyPhtPAyXaKRbwaCoE86ZphNUKLR7Ic/7L0fed9X18RVqwpaurGMBMPeHpNCmcQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Direct",
-        "requested": "[18.5.2, )",
-        "resolved": "18.5.2",
-        "contentHash": "UNcGLx9pVtlXF8MPDR8KDp+/OKKNIJjpzwRyZSt609TSGvaD8mtuQMb5GKZvhMucPp0a5Juvn3kxXDceQZWmAg==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
         "dependencies": {
-          "Microsoft.DiaSymReader": "2.2.3",
-          "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
         }
       },
       "Microsoft.Testing.Extensions.CrashDump": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "wop2zrjwNhHLZfo0UJbTOBe5h9kwQsi2O5+ZPRi41KkFzM5obxWYLIpQYw6p/iBv81/9rT7Jn/IeInMFtkYShg==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "9E6JwVZWHh1uAyQr6rWMG9cossiNtYN9hNB81sioYA233aS5WF7HvwUyHlhPH2stfdYHTjHbt7A/Yt9CViqvNA==",
         "dependencies": {
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.Fakes": {
@@ -132,42 +133,60 @@
           "Microsoft.Testing.Platform": "1.2.1"
         }
       },
+      "Microsoft.Testing.Extensions.GitHubActionsReport": {
+        "type": "Direct",
+        "requested": "[1.0.0-alpha.26363.8, )",
+        "resolved": "1.0.0-alpha.26363.8",
+        "contentHash": "QiBUIcPkePJHNt4CfiJHDfUXgcSu1r6/1WVgbGLUFOc3hsAB4v9bqtuLhRyJ07igpUbj0S2DJpUZKqCybNjMHQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
       "Microsoft.Testing.Extensions.HangDump": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "VR3pTDWbBPZ15pZeXzlQzcsGiQ22sd7+M3OJzaOgLLKojMySnS45F5PPSJ4RHxfge2h52yN9m2hNn5U8YiGm2w==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "ZljG8xsxKEMM8hCxdfLLmRhy2W7gEZoTcx42yPRrzBq+UkRnNVBhOccI4/ojz6pCFjLEtXrDLYosR9zM0oF8dg==",
         "dependencies": {
           "Microsoft.Diagnostics.NETCore.Client": "0.2.607501",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.HotReload": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "2ojTkDg/UyVDyCRzOdD28Qckb4Ds6tWPqk+6+c+vfmIE+nnr9bIVZHJ5ZjnXd2LNT3iUqGtt/4nEAwDPyPLI8Q==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "a3m3pffye6a9u7WRTuodseIu5xWYRdrlT48esu0XWjaElzR1mDXvTUQwq1v5p8eid6uL2crVQeeWj6SqULyglQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.HtmlReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "L90xqdIUcaRqkUgzNluTGr2xP9UaG9zUNC+ryxHyLE0JG5sS5NwsrS2OSkY5D94B+dAjGrHZ77WLm/edAs+Cjg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.Retry": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "YYhoLdZOksV5S+poW4b5Kx9hCcO41YpBcExPgpHlKLf7B+LFyjWryF9zPmKCWV/W7LBpo+HgDZXa5o2WVi5/Eg==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "KYzPIy7K6Yefn9GCoP1J+SP+Ae/51xRNrGpFVwnQUCiNKIJ4fb/UbPWN7Qcq36c5fyseFBfyrw2hKPZAag5zCQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport": {
         "type": "Direct",
-        "requested": "[2.2.3, )",
-        "resolved": "2.2.3",
-        "contentHash": "9Hot3ty5ZVWHrW40k2NPfD0dCaPwIxj7j7VjujNYwpYkYw9AdbejPHjGNkL/gvUWorauJf5IkeDoUeIbS7LuUg==",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
         "dependencies": {
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "ModelContextProtocol": {
@@ -181,22 +200,22 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
         "dependencies": {
-          "MSTest.TestFramework": "4.2.3",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
-          "Microsoft.Testing.Platform.MSBuild": "2.2.3"
+          "MSTest.TestFramework": "4.3.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
         "dependencies": {
-          "MSTest.Analyzers": "4.2.3"
+          "MSTest.Analyzers": "4.3.2"
         }
       },
       "SIL.ReleaseTasks": {
@@ -223,9 +242,9 @@
       },
       "System.Reactive": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "VYaSP2Kt+45GFnr3q7c/b4awT48VvueOJV4jPjdUXi5MxC9mSUy+HkJYtm8rGZ6fC3tNHG9gBu/YwNAR/FYqhg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Direct",
@@ -475,8 +494,8 @@
       },
       "Microsoft.DiaSymReader": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "bhwzJfzyiJM0nXJyNB7Y9OfsEXyxLdDBHG99soIp5JjnPydwkOaBdRCtRtWgQh3noSLi2cSIZ/wpbHNNE9knxQ=="
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
@@ -485,8 +504,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -516,49 +535,49 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "resolved": "2.3.2",
+        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "resolved": "2.3.2",
+        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.3.0",
-        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+        "resolved": "18.4.0",
+        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
       },
       "ModelContextProtocol.Core": {
         "type": "Transitive",
@@ -570,8 +589,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.2.3",
-        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+        "resolved": "4.3.2",
+        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
@@ -646,6 +665,11 @@
         "type": "Transitive",
         "resolved": "3.0.1",
         "contentHash": "37Xq3UfF7gbcKhFhx2dgRIatLCrbkg/99XVSkIi9pJtttmHEfGX483Ix52mO3PPPZI6YNbZjzHfH5hQwwb+X2g=="
+      },
+      "xunit.v3.assert.source": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BzEGm0YpipGWMCdGc+/zDLpVaFUAyx6qqvYyA96SL2MynBPplcoemZ7fa+XU2UMCEQNzEp+1hKQuyw2UF8ethA=="
       },
       "verifiable": {
         "type": "Project",

--- a/test/Verifiable.Tests/test/TreeTraversalTests.cs
+++ b/test/Verifiable.Tests/test/TreeTraversalTests.cs
@@ -46,8 +46,8 @@ internal class TreeTraversalTests
             Assert.HasCount(3, asyncOutputList);
 
             var expectedOrder = new List<Claim> { mainClaim }.Concat(subClaims).ToList();
-            CollectionAssert.AreEqual(expectedOrder, outputList);
-            CollectionAssert.AreEqual(expectedOrder, asyncOutputList);
+            Assert.AreSequenceEqual(expectedOrder, outputList);
+            Assert.AreSequenceEqual(expectedOrder, asyncOutputList);
         }
 
 


### PR DESCRIPTION
- Add an authorization-server registry that rejects two servers sharing an issuer and validates the authorization response iss against it (RFC 9207).
- Bump test dependencies and modernize collection assertions.